### PR TITLE
update cmake include guard from global to dir

### DIFF
--- a/CMSIS/Driver/Include/CMSIS_Driver_Include_Common.cmake
+++ b/CMSIS/Driver/Include/CMSIS_Driver_Include_Common.cmake
@@ -1,5 +1,5 @@
 #Description: Cmsis_driver_include common; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("CMSIS_Driver_Include_Common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/CMSIS/Driver/Include/CMSIS_Driver_Include_I2C.cmake
+++ b/CMSIS/Driver/Include/CMSIS_Driver_Include_I2C.cmake
@@ -1,5 +1,5 @@
 #Description: Cmsis_driver_include i2c; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("CMSIS_Driver_Include_I2C component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/CMSIS/Driver/Include/CMSIS_Driver_Include_SPI.cmake
+++ b/CMSIS/Driver/Include/CMSIS_Driver_Include_SPI.cmake
@@ -1,5 +1,5 @@
 #Description: Cmsis_driver_include spi; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("CMSIS_Driver_Include_SPI component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/CMSIS/Include/CMSIS_Include_common.cmake
+++ b/CMSIS/Include/CMSIS_Include_common.cmake
@@ -1,5 +1,5 @@
 #Description: Cmsis_include_common; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("CMSIS_Include_common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/CMSIS/Include/CMSIS_Include_core_cm0plus.cmake
+++ b/CMSIS/Include/CMSIS_Include_core_cm0plus.cmake
@@ -1,5 +1,5 @@
 #Description: Cmsis_include_core_cm0plus; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("CMSIS_Include_core_cm0plus component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/CMSIS/Include/CMSIS_Include_core_cm33.cmake
+++ b/CMSIS/Include/CMSIS_Include_core_cm33.cmake
@@ -1,5 +1,5 @@
 #Description: Cmsis_include_core_cm33; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("CMSIS_Include_core_cm33 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/CMSIS/Include/CMSIS_Include_core_cm4.cmake
+++ b/CMSIS/Include/CMSIS_Include_core_cm4.cmake
@@ -1,5 +1,5 @@
 #Description: Cmsis_include_core_cm4; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("CMSIS_Include_core_cm4 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/CMSIS/Include/CMSIS_Include_core_cm7.cmake
+++ b/CMSIS/Include/CMSIS_Include_core_cm7.cmake
@@ -1,5 +1,5 @@
 #Description: Cmsis_include_core_cm7; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("CMSIS_Include_core_cm7 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/CMSIS/Include/CMSIS_Include_dsp.cmake
+++ b/CMSIS/Include/CMSIS_Include_dsp.cmake
@@ -1,5 +1,5 @@
 #Description: Cmsis_include_dsp; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("CMSIS_Include_dsp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/boards/evkbimxrt1050/xip/driver_xip_board.cmake
+++ b/boards/evkbimxrt1050/xip/driver_xip_board.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Board Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_board component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/boards/evkmimxrt1010/xip/driver_xip_board.cmake
+++ b/boards/evkmimxrt1010/xip/driver_xip_board.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Board Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_board component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/boards/evkmimxrt1015/xip/driver_xip_board.cmake
+++ b/boards/evkmimxrt1015/xip/driver_xip_board.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Board Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_board component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/boards/evkmimxrt1020/xip/driver_xip_board.cmake
+++ b/boards/evkmimxrt1020/xip/driver_xip_board.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Board Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_board component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/boards/evkmimxrt1024/xip/driver_xip_board.cmake
+++ b/boards/evkmimxrt1024/xip/driver_xip_board.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Board Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_board component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/boards/evkmimxrt1060/xip/driver_xip_board.cmake
+++ b/boards/evkmimxrt1060/xip/driver_xip_board.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Board Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_board component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/boards/evkmimxrt1064/xip/driver_xip_board.cmake
+++ b/boards/evkmimxrt1064/xip/driver_xip_board.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Board Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_board component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/boards/evkmimxrt685/flash_config/driver_flash_config.cmake
+++ b/boards/evkmimxrt685/flash_config/driver_flash_config.cmake
@@ -1,5 +1,5 @@
 #Description: Flash config; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flash_config component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/IS42SM16800H/driver_IS42SM16800H.cmake
+++ b/components/IS42SM16800H/driver_IS42SM16800H.cmake
@@ -1,5 +1,5 @@
 #Description: Driver is42sm16800h; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_IS42SM16800H component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/ak4497/driver_ak4497.cmake
+++ b/components/codec/ak4497/driver_ak4497.cmake
@@ -1,5 +1,5 @@
 #Description: Driver ak4497; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ak4497 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/cs42888/driver_cs42888.cmake
+++ b/components/codec/cs42888/driver_cs42888.cmake
@@ -1,5 +1,5 @@
 #Description: Driver cs42888; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cs42888 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/da7212/driver_dialog7212.cmake
+++ b/components/codec/da7212/driver_dialog7212.cmake
@@ -1,5 +1,5 @@
 #Description: Driver dialog7212; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dialog7212 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/driver_codec.cmake
+++ b/components/codec/driver_codec.cmake
@@ -1,5 +1,5 @@
 #Description: Driver codec; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_codec component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_LPC51U68.cmake
+++ b/components/codec/i2c/component_codec_i2c_LPC51U68.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_LPC54114_cm4.cmake
+++ b/components/codec/i2c/component_codec_i2c_LPC54114_cm4.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_LPC54628.cmake
+++ b/components/codec/i2c/component_codec_i2c_LPC54628.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_LPC54S018.cmake
+++ b/components/codec/i2c/component_codec_i2c_LPC54S018.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_LPC54S018M.cmake
+++ b/components/codec/i2c/component_codec_i2c_LPC54S018M.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_LPC55S16.cmake
+++ b/components/codec/i2c/component_codec_i2c_LPC55S16.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_LPC55S28.cmake
+++ b/components/codec/i2c/component_codec_i2c_LPC55S28.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_LPC55S69_cm33_core0.cmake
+++ b/components/codec/i2c/component_codec_i2c_LPC55S69_cm33_core0.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MCIMX7U5.cmake
+++ b/components/codec/i2c/component_codec_i2c_MCIMX7U5.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMX8MM6.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMX8MM6.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMX8QM6_cm4_core0.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMX8QM6_cm4_core0.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMX8QM6_cm4_core1.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMX8QM6_cm4_core1.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMX8QX6.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMX8QX6.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMXRT1011.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMXRT1011.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMXRT1015.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMXRT1015.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMXRT1021.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMXRT1021.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMXRT1024.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMXRT1024.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMXRT1052.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMXRT1052.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMXRT1062.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMXRT1062.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMXRT1064.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMXRT1064.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MIMXRT685S_cm33.cmake
+++ b/components/codec/i2c/component_codec_i2c_MIMXRT685S_cm33.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/i2c/component_codec_i2c_MK66F18.cmake
+++ b/components/codec/i2c/component_codec_i2c_MK66F18.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/port/component_codec_ak4497_adapter.cmake
+++ b/components/codec/port/component_codec_ak4497_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_ak4497_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_ak4497_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/port/component_codec_wm8524_adapter.cmake
+++ b/components/codec/port/component_codec_wm8524_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component codec_wm8524_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_codec_wm8524_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/port/cs42888/component_cs42888_adapter.cmake
+++ b/components/codec/port/cs42888/component_cs42888_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component cs42888_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_cs42888_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/port/da7212/component_da7212_adapter.cmake
+++ b/components/codec/port/da7212/component_da7212_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component da7212_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_da7212_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/port/tfa9xxx/component_tfa9xxx_adapter.cmake
+++ b/components/codec/port/tfa9xxx/component_tfa9xxx_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component tfa9xxx_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_tfa9xxx_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/port/wm8524/component_wm8524_adapter.cmake
+++ b/components/codec/port/wm8524/component_wm8524_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component wm8524_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_wm8524_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/port/wm8904/component_wm8904_adapter.cmake
+++ b/components/codec/port/wm8904/component_wm8904_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component wm8904_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_wm8904_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/port/wm8960/component_wm8960_adapter.cmake
+++ b/components/codec/port/wm8960/component_wm8960_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component wm8960_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_wm8960_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/tfa9xxx/driver_tfa9xxx.cmake
+++ b/components/codec/tfa9xxx/driver_tfa9xxx.cmake
@@ -1,5 +1,5 @@
 #Description: Driver tfa9xxx; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_tfa9xxx component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/wm8524/driver_wm8524.cmake
+++ b/components/codec/wm8524/driver_wm8524.cmake
@@ -1,5 +1,5 @@
 #Description: Driver wm8524; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_wm8524 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/wm8904/driver_wm8904.cmake
+++ b/components/codec/wm8904/driver_wm8904.cmake
@@ -1,5 +1,5 @@
 #Description: Driver wm8904; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_wm8904 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/codec/wm8960/driver_wm8960.cmake
+++ b/components/codec/wm8960/driver_wm8960.cmake
@@ -1,5 +1,5 @@
 #Description: Driver wm8960; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_wm8960 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/ft5406/driver_ft5406.cmake
+++ b/components/ft5406/driver_ft5406.cmake
@@ -1,5 +1,5 @@
 #Description: Driver ft5406; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ft5406 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/fxos8700cq/driver_fxos8700cq.cmake
+++ b/components/fxos8700cq/driver_fxos8700cq.cmake
@@ -1,5 +1,5 @@
 #Description: Driver fxos8700cq; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_fxos8700cq component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/i2c/component_flexcomm_i2c_adapter.cmake
+++ b/components/i2c/component_flexcomm_i2c_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component flexcomm_i2c_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_flexcomm_i2c_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/i2c/component_i2c_adapter.cmake
+++ b/components/i2c/component_i2c_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component i2c_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_i2c_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/i2c/component_i3c_adapter.cmake
+++ b/components/i2c/component_i3c_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component i3c_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_i3c_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/i2c/component_ii2c_adapter.cmake
+++ b/components/i2c/component_ii2c_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component ii2c_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_ii2c_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/i2c/component_lpi2c_adapter.cmake
+++ b/components/i2c/component_lpi2c_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component lpi2c_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_lpi2c_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/lists/component_lists.cmake
+++ b/components/lists/component_lists.cmake
@@ -1,5 +1,5 @@
 #Description: Component lists; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_lists component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/mma8451q/driver_mma8451q.cmake
+++ b/components/mma8451q/driver_mma8451q.cmake
@@ -1,5 +1,5 @@
 #Description: Driver mma8451q; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mma8451q component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/mx25r_flash/driver_mx25r_flash.cmake
+++ b/components/mx25r_flash/driver_mx25r_flash.cmake
@@ -1,5 +1,5 @@
 #Description: Driver mx25r_flash; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mx25r_flash component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/osa/component_osa.cmake
+++ b/components/osa/component_osa.cmake
@@ -1,5 +1,5 @@
 #Description: Component osa; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_osa component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/osa/component_osa_bm.cmake
+++ b/components/osa/component_osa_bm.cmake
@@ -1,5 +1,5 @@
 #Description: Component osa_bm; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_osa_bm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/osa/component_osa_free_rtos.cmake
+++ b/components/osa/component_osa_free_rtos.cmake
@@ -1,5 +1,5 @@
 #Description: Component osa_free_rtos; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_osa_free_rtos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/pca9420/driver_pca9420.cmake
+++ b/components/pca9420/driver_pca9420.cmake
@@ -1,5 +1,5 @@
 #Description: Driver pca9420; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pca9420 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/pf1550/driver_pf1550.cmake
+++ b/components/pf1550/driver_pf1550.cmake
@@ -1,5 +1,5 @@
 #Description: Driver pf1550; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pf1550 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/phy/device/phyar8031/driver_phy-device-ar8031.cmake
+++ b/components/phy/device/phyar8031/driver_phy-device-ar8031.cmake
@@ -1,5 +1,5 @@
 #Description: Driver phy-device-ar8031; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_phy-device-ar8031 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/phy/device/phyksz8081/driver_phy-device-ksz8081.cmake
+++ b/components/phy/device/phyksz8081/driver_phy-device-ksz8081.cmake
@@ -1,5 +1,5 @@
 #Description: Driver phy-device-ksz8081; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_phy-device-ksz8081 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/phy/device/phylan8720a/driver_phy-device-lan8720a.cmake
+++ b/components/phy/device/phylan8720a/driver_phy-device-lan8720a.cmake
@@ -1,5 +1,5 @@
 #Description: Driver phy-device-lan8720a; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_phy-device-lan8720a component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/phy/driver_mdio-common.cmake
+++ b/components/phy/driver_mdio-common.cmake
@@ -1,5 +1,5 @@
 #Description: Driver mdio-common; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mdio-common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/phy/driver_phy-common.cmake
+++ b/components/phy/driver_phy-common.cmake
@@ -1,5 +1,5 @@
 #Description: Driver phy-common; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_phy-common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/phy/mdio/enet/driver_mdio-enet.cmake
+++ b/components/phy/mdio/enet/driver_mdio-enet.cmake
@@ -1,5 +1,5 @@
 #Description: Driver mdio-enet; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mdio-enet component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/phy/mdio/lpc_enet/driver_mdio-lpc-enet.cmake
+++ b/components/phy/mdio/lpc_enet/driver_mdio-lpc-enet.cmake
@@ -1,5 +1,5 @@
 #Description: Driver mdio-lpc-enet; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mdio-lpc-enet component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/serial_manager/component_serial_manager.cmake
+++ b/components/serial_manager/component_serial_manager.cmake
@@ -1,5 +1,5 @@
 #Description: Serial Manager; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_serial_manager component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/serial_manager/component_serial_manager_swo.cmake
+++ b/components/serial_manager/component_serial_manager_swo.cmake
@@ -1,5 +1,5 @@
 #Description: Serial Manager Swo; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_serial_manager_swo component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/serial_manager/component_serial_manager_uart.cmake
+++ b/components/serial_manager/component_serial_manager_uart.cmake
@@ -1,5 +1,5 @@
 #Description: Serial Manager uart; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_serial_manager_uart component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/slcd_engine/GDH-1247WP/driver_slcd_gdh_1247wp.cmake
+++ b/components/slcd_engine/GDH-1247WP/driver_slcd_gdh_1247wp.cmake
@@ -1,5 +1,5 @@
 #Description: Driver slcd_gdh_1247wp; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_slcd_gdh_1247wp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/slcd_engine/LCD-S401M16KR/driver_slcd_lcd_s401m16kr.cmake
+++ b/components/slcd_engine/LCD-S401M16KR/driver_slcd_lcd_s401m16kr.cmake
@@ -1,5 +1,5 @@
 #Description: Driver slcd_lcd_s401m16kr; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_slcd_lcd_s401m16kr component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/slcd_engine/driver_slcd_engine.cmake
+++ b/components/slcd_engine/driver_slcd_engine.cmake
@@ -1,5 +1,5 @@
 #Description: Driver slcd_engine; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_slcd_engine component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/srtm/driver_srtm.cmake
+++ b/components/srtm/driver_srtm.cmake
@@ -1,5 +1,5 @@
 #Description: Driver srtm; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_srtm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/srtm/port/driver_srtm_freertos.cmake
+++ b/components/srtm/port/driver_srtm_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: Driver srtm freertos; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_srtm_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/ssd1963/driver_ssd1963.cmake
+++ b/components/ssd1963/driver_ssd1963.cmake
@@ -1,5 +1,5 @@
 #Description: Driver ssd1963; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ssd1963 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/timer/component_ctimer_adapter.cmake
+++ b/components/timer/component_ctimer_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: Component ctimer_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_ctimer_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/uart/component_iuart_adapter.cmake
+++ b/components/uart/component_iuart_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: iuart_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_iuart_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/uart/component_lpuart_adapter.cmake
+++ b/components/uart/component_lpuart_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: lpuart_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_lpuart_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/uart/component_miniusart_adapter.cmake
+++ b/components/uart/component_miniusart_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: miniusart_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_miniusart_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/uart/component_uart_adapter.cmake
+++ b/components/uart/component_uart_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: uart_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_uart_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/uart/component_usart_adapter.cmake
+++ b/components/uart/component_usart_adapter.cmake
@@ -1,5 +1,5 @@
 #Description: usart_adapter; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("component_usart_adapter component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/device/driver_camera-device-common.cmake
+++ b/components/video/camera/device/driver_camera-device-common.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-device-common; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-device-common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/device/max9286/driver_camera-device-max9286.cmake
+++ b/components/video/camera/device/max9286/driver_camera-device-max9286.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-device-max9286; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-device-max9286 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/device/mt9m114/driver_camera-device-mt9m114.cmake
+++ b/components/video/camera/device/mt9m114/driver_camera-device-mt9m114.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-device-mt9m114; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-device-mt9m114 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/device/ov5640/driver_camera-device-ov5640.cmake
+++ b/components/video/camera/device/ov5640/driver_camera-device-ov5640.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-device-ov5640; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-device-ov5640 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/device/ov7725/driver_camera-device-ov7725.cmake
+++ b/components/video/camera/device/ov7725/driver_camera-device-ov7725.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-device-ov7725; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-device-ov7725 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/device/sccb/driver_camera-device-sccb.cmake
+++ b/components/video/camera/device/sccb/driver_camera-device-sccb.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-device-sccb; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-device-sccb component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/driver_camera-common.cmake
+++ b/components/video/camera/driver_camera-common.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-common; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/receiver/csi/driver_camera-receiver-csi.cmake
+++ b/components/video/camera/receiver/csi/driver_camera-receiver-csi.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-receiver-csi; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-receiver-csi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/receiver/driver_camera-receiver-common.cmake
+++ b/components/video/camera/receiver/driver_camera-receiver-common.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-receiver-common; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-receiver-common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/camera/receiver/isi/driver_camera-receiver-isi.cmake
+++ b/components/video/camera/receiver/isi/driver_camera-receiver-isi.cmake
@@ -1,5 +1,5 @@
 #Description: Driver camera-receiver-isi; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_camera-receiver-isi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/display/adv7535/driver_display-adv7535.cmake
+++ b/components/video/display/adv7535/driver_display-adv7535.cmake
@@ -1,5 +1,5 @@
 #Description: Driver display-adv7535; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_display-adv7535 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/display/dbi/driver_dbi.cmake
+++ b/components/video/display/dbi/driver_dbi.cmake
@@ -1,5 +1,5 @@
 #Description: Driver dbi; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dbi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/display/dbi/flexio/driver_dbi_flexio_edma.cmake
+++ b/components/video/display/dbi/flexio/driver_dbi_flexio_edma.cmake
@@ -1,5 +1,5 @@
 #Description: Driver dbi_flexio_edma; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dbi_flexio_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/display/dc/driver_dc-fb-common.cmake
+++ b/components/video/display/dc/driver_dc-fb-common.cmake
@@ -1,5 +1,5 @@
 #Description: Driver dc-fb-common; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dc-fb-common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/display/dc/elcdif/driver_dc-fb-elcdif.cmake
+++ b/components/video/display/dc/elcdif/driver_dc-fb-elcdif.cmake
@@ -1,5 +1,5 @@
 #Description: Driver dc-fb-elcdif; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dc-fb-elcdif component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/display/driver_display-common.cmake
+++ b/components/video/display/driver_display-common.cmake
@@ -1,5 +1,5 @@
 #Description: Driver display-common; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_display-common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/display/it6263/driver_display-it6263.cmake
+++ b/components/video/display/it6263/driver_display-it6263.cmake
@@ -1,5 +1,5 @@
 #Description: Driver display-it6263; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_display-it6263 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/display/mipi_dsi_cmd/driver_display-mipi-dsi-cmd.cmake
+++ b/components/video/display/mipi_dsi_cmd/driver_display-mipi-dsi-cmd.cmake
@@ -1,5 +1,5 @@
 #Description: Driver display-mipi-dsi-cmd; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_display-mipi-dsi-cmd component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/display/rm67191/driver_display-rm67191.cmake
+++ b/components/video/display/rm67191/driver_display-rm67191.cmake
@@ -1,5 +1,5 @@
 #Description: Driver display-rm67191; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_display-rm67191 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/driver_video-common.cmake
+++ b/components/video/driver_video-common.cmake
@@ -1,5 +1,5 @@
 #Description: Driver video-common; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_video-common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/components/video/i2c/driver_video-i2c.cmake
+++ b/components/video/i2c/driver_video-i2c.cmake
@@ -1,5 +1,5 @@
 #Description: Driver video-i2c; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_video-i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2A31A/drivers/driver_reset.cmake
+++ b/devices/K32L2A31A/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2A41A/device_CMSIS.cmake
+++ b/devices/K32L2A41A/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2A41A/device_startup.cmake
+++ b/devices/K32L2A41A/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2A41A/device_system.cmake
+++ b/devices/K32L2A41A/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2A41A/drivers/driver_clock.cmake
+++ b/devices/K32L2A41A/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2A41A/drivers/driver_reset.cmake
+++ b/devices/K32L2A41A/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2A41A/utilities/utility_notifier.cmake
+++ b/devices/K32L2A41A/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2A41A/utilities/utility_shell.cmake
+++ b/devices/K32L2A41A/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2B11A/drivers/driver_reset.cmake
+++ b/devices/K32L2B11A/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2B21A/drivers/driver_reset.cmake
+++ b/devices/K32L2B21A/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2B31A/device_CMSIS.cmake
+++ b/devices/K32L2B31A/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2B31A/device_startup.cmake
+++ b/devices/K32L2B31A/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2B31A/device_system.cmake
+++ b/devices/K32L2B31A/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2B31A/drivers/driver_clock.cmake
+++ b/devices/K32L2B31A/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2B31A/drivers/driver_reset.cmake
+++ b/devices/K32L2B31A/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2B31A/utilities/utility_notifier.cmake
+++ b/devices/K32L2B31A/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L2B31A/utilities/utility_shell.cmake
+++ b/devices/K32L2B31A/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L3A60/device_startup_K32L3A60_cm0plus.cmake
+++ b/devices/K32L3A60/device_startup_K32L3A60_cm0plus.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L3A60/device_startup_K32L3A60_cm4.cmake
+++ b/devices/K32L3A60/device_startup_K32L3A60_cm4.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L3A60/device_system_K32L3A60_cm0plus.cmake
+++ b/devices/K32L3A60/device_system_K32L3A60_cm0plus.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L3A60/device_system_K32L3A60_cm4.cmake
+++ b/devices/K32L3A60/device_system_K32L3A60_cm4.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L3A60/drivers/cm0plus/driver_cache_lplmem.cmake
+++ b/devices/K32L3A60/drivers/cm0plus/driver_cache_lplmem.cmake
@@ -1,5 +1,5 @@
 #Description: CACHE Lplmem Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cache_lplmem component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L3A60/drivers/cm4/driver_cache_lpcac.cmake
+++ b/devices/K32L3A60/drivers/cm4/driver_cache_lpcac.cmake
@@ -1,5 +1,5 @@
 #Description: CACHE Lpcac Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cache_lpcac component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L3A60/drivers/driver_clock.cmake
+++ b/devices/K32L3A60/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L3A60/drivers/driver_reset.cmake
+++ b/devices/K32L3A60/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/K32L3A60/utilities/utility_shell.cmake
+++ b/devices/K32L3A60/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC51U68/device_CMSIS.cmake
+++ b/devices/LPC51U68/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC51U68/device_startup.cmake
+++ b/devices/LPC51U68/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC51U68/device_system.cmake
+++ b/devices/LPC51U68/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC51U68/driver_power.cmake
+++ b/devices/LPC51U68/driver_power.cmake
@@ -1,5 +1,5 @@
 #Description: power; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC51U68/drivers/driver_clock.cmake
+++ b/devices/LPC51U68/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC51U68/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC51U68/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC51U68/drivers/driver_reset.cmake
+++ b/devices/LPC51U68/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC51U68/utilities/utility_shell.cmake
+++ b/devices/LPC51U68/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54005/drivers/driver_reset.cmake
+++ b/devices/LPC54005/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54016/drivers/driver_reset.cmake
+++ b/devices/LPC54016/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54018/drivers/driver_reset.cmake
+++ b/devices/LPC54018/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54018M/drivers/driver_reset.cmake
+++ b/devices/LPC54018M/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54113/drivers/driver_reset.cmake
+++ b/devices/LPC54113/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54114/device_startup_LPC54114_cm0plus.cmake
+++ b/devices/LPC54114/device_startup_LPC54114_cm0plus.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54114/device_startup_LPC54114_cm4.cmake
+++ b/devices/LPC54114/device_startup_LPC54114_cm4.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54114/device_system_LPC54114_cm0plus.cmake
+++ b/devices/LPC54114/device_system_LPC54114_cm0plus.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54114/device_system_LPC54114_cm4.cmake
+++ b/devices/LPC54114/device_system_LPC54114_cm4.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54114/driver_power.cmake
+++ b/devices/LPC54114/driver_power.cmake
@@ -1,5 +1,5 @@
 #Description: power; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54114/drivers/driver_clock.cmake
+++ b/devices/LPC54114/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54114/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC54114/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54114/drivers/driver_reset.cmake
+++ b/devices/LPC54114/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54114/utilities/utility_shell.cmake
+++ b/devices/LPC54114/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54605/drivers/driver_reset.cmake
+++ b/devices/LPC54605/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54606/drivers/driver_reset.cmake
+++ b/devices/LPC54606/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54607/drivers/driver_reset.cmake
+++ b/devices/LPC54607/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54608/drivers/driver_reset.cmake
+++ b/devices/LPC54608/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54616/drivers/driver_reset.cmake
+++ b/devices/LPC54616/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54618/drivers/driver_reset.cmake
+++ b/devices/LPC54618/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54628/device_CMSIS.cmake
+++ b/devices/LPC54628/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54628/device_startup.cmake
+++ b/devices/LPC54628/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54628/device_system.cmake
+++ b/devices/LPC54628/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54628/driver_power.cmake
+++ b/devices/LPC54628/driver_power.cmake
@@ -1,5 +1,5 @@
 #Description: power; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54628/drivers/driver_clock.cmake
+++ b/devices/LPC54628/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54628/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC54628/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54628/drivers/driver_reset.cmake
+++ b/devices/LPC54628/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54628/utilities/utility_shell.cmake
+++ b/devices/LPC54628/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S005/drivers/driver_reset.cmake
+++ b/devices/LPC54S005/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S016/drivers/driver_reset.cmake
+++ b/devices/LPC54S016/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018/device_CMSIS.cmake
+++ b/devices/LPC54S018/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018/device_startup.cmake
+++ b/devices/LPC54S018/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018/device_system.cmake
+++ b/devices/LPC54S018/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018/driver_power.cmake
+++ b/devices/LPC54S018/driver_power.cmake
@@ -1,5 +1,5 @@
 #Description: power; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018/drivers/driver_clock.cmake
+++ b/devices/LPC54S018/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC54S018/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018/drivers/driver_reset.cmake
+++ b/devices/LPC54S018/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018/utilities/utility_shell.cmake
+++ b/devices/LPC54S018/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018M/device_CMSIS.cmake
+++ b/devices/LPC54S018M/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018M/device_startup.cmake
+++ b/devices/LPC54S018M/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018M/device_system.cmake
+++ b/devices/LPC54S018M/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018M/driver_power.cmake
+++ b/devices/LPC54S018M/driver_power.cmake
@@ -1,5 +1,5 @@
 #Description: power; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018M/drivers/driver_clock.cmake
+++ b/devices/LPC54S018M/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018M/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC54S018M/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018M/drivers/driver_reset.cmake
+++ b/devices/LPC54S018M/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC54S018M/utilities/utility_shell.cmake
+++ b/devices/LPC54S018M/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC5512/drivers/driver_reset.cmake
+++ b/devices/LPC5512/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC5514/drivers/driver_reset.cmake
+++ b/devices/LPC5514/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC5516/drivers/driver_reset.cmake
+++ b/devices/LPC5516/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC5526/drivers/driver_reset.cmake
+++ b/devices/LPC5526/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC5528/drivers/driver_reset.cmake
+++ b/devices/LPC5528/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S14/drivers/driver_reset.cmake
+++ b/devices/LPC55S14/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S16/device_CMSIS.cmake
+++ b/devices/LPC55S16/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S16/device_startup.cmake
+++ b/devices/LPC55S16/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S16/device_system.cmake
+++ b/devices/LPC55S16/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S16/driver_power.cmake
+++ b/devices/LPC55S16/driver_power.cmake
@@ -1,5 +1,5 @@
 #Description: power; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S16/drivers/driver_clock.cmake
+++ b/devices/LPC55S16/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S16/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC55S16/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S16/drivers/driver_reset.cmake
+++ b/devices/LPC55S16/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S16/utilities/utility_shell.cmake
+++ b/devices/LPC55S16/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S26/drivers/driver_reset.cmake
+++ b/devices/LPC55S26/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S28/device_CMSIS.cmake
+++ b/devices/LPC55S28/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S28/device_startup.cmake
+++ b/devices/LPC55S28/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S28/device_system.cmake
+++ b/devices/LPC55S28/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S28/driver_power.cmake
+++ b/devices/LPC55S28/driver_power.cmake
@@ -1,5 +1,5 @@
 #Description: power; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S28/drivers/driver_clock.cmake
+++ b/devices/LPC55S28/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S28/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC55S28/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S28/drivers/driver_reset.cmake
+++ b/devices/LPC55S28/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S28/utilities/utility_shell.cmake
+++ b/devices/LPC55S28/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S66/drivers/driver_reset.cmake
+++ b/devices/LPC55S66/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/device_CMSIS.cmake
+++ b/devices/LPC55S69/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/device_startup_LPC55S69_cm33_core0.cmake
+++ b/devices/LPC55S69/device_startup_LPC55S69_cm33_core0.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/device_startup_LPC55S69_cm33_core1.cmake
+++ b/devices/LPC55S69/device_startup_LPC55S69_cm33_core1.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/device_system_LPC55S69_cm33_core0.cmake
+++ b/devices/LPC55S69/device_system_LPC55S69_cm33_core0.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/device_system_LPC55S69_cm33_core1.cmake
+++ b/devices/LPC55S69/device_system_LPC55S69_cm33_core1.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/driver_power.cmake
+++ b/devices/LPC55S69/driver_power.cmake
@@ -1,5 +1,5 @@
 #Description: power; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/driver_power_s.cmake
+++ b/devices/LPC55S69/driver_power_s.cmake
@@ -1,5 +1,5 @@
 #Description: power_s; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power_s component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/drivers/driver_clock.cmake
+++ b/devices/LPC55S69/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC55S69/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/drivers/driver_reset.cmake
+++ b/devices/LPC55S69/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC55S69/utilities/utility_shell.cmake
+++ b/devices/LPC55S69/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC802/device_CMSIS.cmake
+++ b/devices/LPC802/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC802/device_startup.cmake
+++ b/devices/LPC802/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC802/device_system.cmake
+++ b/devices/LPC802/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC802/drivers/driver_clock.cmake
+++ b/devices/LPC802/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC802/drivers/driver_power_no_lib.cmake
+++ b/devices/LPC802/drivers/driver_power_no_lib.cmake
@@ -1,5 +1,5 @@
 #Description: power_no_lib; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power_no_lib component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC802/drivers/driver_reset.cmake
+++ b/devices/LPC802/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC802/drivers/driver_rom_api.cmake
+++ b/devices/LPC802/drivers/driver_rom_api.cmake
@@ -1,5 +1,5 @@
 #Description: Rom_api Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rom_api component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC802/drivers/driver_swm_connections.cmake
+++ b/devices/LPC802/drivers/driver_swm_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Swm_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_swm_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC802/drivers/driver_syscon_connections.cmake
+++ b/devices/LPC802/drivers/driver_syscon_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Syscon_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_syscon_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC804/device_CMSIS.cmake
+++ b/devices/LPC804/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC804/device_startup.cmake
+++ b/devices/LPC804/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC804/device_system.cmake
+++ b/devices/LPC804/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC804/drivers/driver_clock.cmake
+++ b/devices/LPC804/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC804/drivers/driver_power_no_lib.cmake
+++ b/devices/LPC804/drivers/driver_power_no_lib.cmake
@@ -1,5 +1,5 @@
 #Description: power_no_lib; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power_no_lib component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC804/drivers/driver_reset.cmake
+++ b/devices/LPC804/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC804/drivers/driver_rom_api.cmake
+++ b/devices/LPC804/drivers/driver_rom_api.cmake
@@ -1,5 +1,5 @@
 #Description: Rom_api Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rom_api component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC804/drivers/driver_swm_connections.cmake
+++ b/devices/LPC804/drivers/driver_swm_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Swm_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_swm_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC804/drivers/driver_syscon_connections.cmake
+++ b/devices/LPC804/drivers/driver_syscon_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Syscon_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_syscon_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC810/drivers/driver_reset.cmake
+++ b/devices/LPC810/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC811/drivers/driver_reset.cmake
+++ b/devices/LPC811/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC812/device_CMSIS.cmake
+++ b/devices/LPC812/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC812/device_startup.cmake
+++ b/devices/LPC812/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC812/device_system.cmake
+++ b/devices/LPC812/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC812/drivers/driver_clock.cmake
+++ b/devices/LPC812/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC812/drivers/driver_power_no_lib.cmake
+++ b/devices/LPC812/drivers/driver_power_no_lib.cmake
@@ -1,5 +1,5 @@
 #Description: power_no_lib; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power_no_lib component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC812/drivers/driver_reset.cmake
+++ b/devices/LPC812/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC812/drivers/driver_swm_connections.cmake
+++ b/devices/LPC812/drivers/driver_swm_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Swm_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_swm_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC812/drivers/driver_syscon_connections.cmake
+++ b/devices/LPC812/drivers/driver_syscon_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Syscon_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_syscon_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC822/drivers/driver_reset.cmake
+++ b/devices/LPC822/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC824/device_CMSIS.cmake
+++ b/devices/LPC824/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC824/device_startup.cmake
+++ b/devices/LPC824/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC824/device_system.cmake
+++ b/devices/LPC824/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC824/drivers/driver_clock.cmake
+++ b/devices/LPC824/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC824/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC824/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC824/drivers/driver_power_no_lib.cmake
+++ b/devices/LPC824/drivers/driver_power_no_lib.cmake
@@ -1,5 +1,5 @@
 #Description: power_no_lib; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power_no_lib component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC824/drivers/driver_reset.cmake
+++ b/devices/LPC824/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC824/drivers/driver_swm_connections.cmake
+++ b/devices/LPC824/drivers/driver_swm_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Swm_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_swm_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC824/drivers/driver_syscon_connections.cmake
+++ b/devices/LPC824/drivers/driver_syscon_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Syscon_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_syscon_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC832/drivers/driver_reset.cmake
+++ b/devices/LPC832/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC834/drivers/driver_reset.cmake
+++ b/devices/LPC834/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC844/drivers/driver_reset.cmake
+++ b/devices/LPC844/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC845/device_CMSIS.cmake
+++ b/devices/LPC845/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC845/device_startup.cmake
+++ b/devices/LPC845/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC845/device_system.cmake
+++ b/devices/LPC845/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC845/drivers/driver_clock.cmake
+++ b/devices/LPC845/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC845/drivers/driver_inputmux_connections.cmake
+++ b/devices/LPC845/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC845/drivers/driver_power_no_lib.cmake
+++ b/devices/LPC845/drivers/driver_power_no_lib.cmake
@@ -1,5 +1,5 @@
 #Description: power_no_lib; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power_no_lib component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC845/drivers/driver_reset.cmake
+++ b/devices/LPC845/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC845/drivers/driver_swm_connections.cmake
+++ b/devices/LPC845/drivers/driver_swm_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Swm_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_swm_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/LPC845/drivers/driver_syscon_connections.cmake
+++ b/devices/LPC845/drivers/driver_syscon_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Syscon_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_syscon_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MCIMX7U3/drivers/driver_reset.cmake
+++ b/devices/MCIMX7U3/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MCIMX7U5/device_CMSIS.cmake
+++ b/devices/MCIMX7U5/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MCIMX7U5/device_startup.cmake
+++ b/devices/MCIMX7U5/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MCIMX7U5/drivers/driver_clock.cmake
+++ b/devices/MCIMX7U5/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MCIMX7U5/drivers/driver_reset.cmake
+++ b/devices/MCIMX7U5/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MCIMX7U5/utilities/utility_shell.cmake
+++ b/devices/MCIMX7U5/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8DX1/drivers/driver_reset.cmake
+++ b/devices/MIMX8DX1/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8DX2/drivers/driver_reset.cmake
+++ b/devices/MIMX8DX2/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8DX3/drivers/driver_reset.cmake
+++ b/devices/MIMX8DX3/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8DX4/drivers/driver_reset.cmake
+++ b/devices/MIMX8DX4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8DX5/drivers/driver_reset.cmake
+++ b/devices/MIMX8DX5/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8DX6/drivers/driver_reset.cmake
+++ b/devices/MIMX8DX6/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MD6/drivers/driver_reset.cmake
+++ b/devices/MIMX8MD6/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MD7/drivers/driver_reset.cmake
+++ b/devices/MIMX8MD7/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM1/drivers/driver_reset.cmake
+++ b/devices/MIMX8MM1/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM2/drivers/driver_reset.cmake
+++ b/devices/MIMX8MM2/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM3/drivers/driver_reset.cmake
+++ b/devices/MIMX8MM3/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM4/drivers/driver_reset.cmake
+++ b/devices/MIMX8MM4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM5/drivers/driver_reset.cmake
+++ b/devices/MIMX8MM5/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM6/device_CMSIS.cmake
+++ b/devices/MIMX8MM6/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM6/device_startup.cmake
+++ b/devices/MIMX8MM6/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM6/device_system.cmake
+++ b/devices/MIMX8MM6/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM6/drivers/driver_clock.cmake
+++ b/devices/MIMX8MM6/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM6/drivers/driver_memory.cmake
+++ b/devices/MIMX8MM6/drivers/driver_memory.cmake
@@ -1,5 +1,5 @@
 #Description: Memory Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_memory component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MM6/drivers/driver_reset.cmake
+++ b/devices/MIMX8MM6/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN1/drivers/driver_reset.cmake
+++ b/devices/MIMX8MN1/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN2/drivers/driver_reset.cmake
+++ b/devices/MIMX8MN2/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN3/drivers/driver_reset.cmake
+++ b/devices/MIMX8MN3/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN4/drivers/driver_reset.cmake
+++ b/devices/MIMX8MN4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN5/drivers/driver_reset.cmake
+++ b/devices/MIMX8MN5/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN6/device_CMSIS.cmake
+++ b/devices/MIMX8MN6/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN6/device_startup.cmake
+++ b/devices/MIMX8MN6/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN6/device_system.cmake
+++ b/devices/MIMX8MN6/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN6/drivers/driver_clock.cmake
+++ b/devices/MIMX8MN6/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN6/drivers/driver_memory.cmake
+++ b/devices/MIMX8MN6/drivers/driver_memory.cmake
@@ -1,5 +1,5 @@
 #Description: Memory Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_memory component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MN6/drivers/driver_reset.cmake
+++ b/devices/MIMX8MN6/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MQ5/drivers/driver_reset.cmake
+++ b/devices/MIMX8MQ5/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MQ6/device_CMSIS.cmake
+++ b/devices/MIMX8MQ6/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MQ6/device_startup.cmake
+++ b/devices/MIMX8MQ6/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MQ6/device_system.cmake
+++ b/devices/MIMX8MQ6/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MQ6/drivers/driver_clock.cmake
+++ b/devices/MIMX8MQ6/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MQ6/drivers/driver_reset.cmake
+++ b/devices/MIMX8MQ6/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8MQ7/drivers/driver_reset.cmake
+++ b/devices/MIMX8MQ7/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QM6/device_CMSIS.cmake
+++ b/devices/MIMX8QM6/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QM6/device_startup_MIMX8QM6_cm4_core0.cmake
+++ b/devices/MIMX8QM6/device_startup_MIMX8QM6_cm4_core0.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QM6/device_startup_MIMX8QM6_cm4_core1.cmake
+++ b/devices/MIMX8QM6/device_startup_MIMX8QM6_cm4_core1.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QM6/drivers/driver_clock.cmake
+++ b/devices/MIMX8QM6/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QM6/drivers/driver_memory.cmake
+++ b/devices/MIMX8QM6/drivers/driver_memory.cmake
@@ -1,5 +1,5 @@
 #Description: Memory Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_memory component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QM6/drivers/driver_reset.cmake
+++ b/devices/MIMX8QM6/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QM6/drivers/driver_sc_event.cmake
+++ b/devices/MIMX8QM6/drivers/driver_sc_event.cmake
@@ -1,5 +1,5 @@
 #Description: RTC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sc_event component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QM6/scfw_api/driver_scfw_api.cmake
+++ b/devices/MIMX8QM6/scfw_api/driver_scfw_api.cmake
@@ -1,5 +1,5 @@
 #Description: SCFW API Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_scfw_api component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX1/drivers/driver_reset.cmake
+++ b/devices/MIMX8QX1/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX2/drivers/driver_reset.cmake
+++ b/devices/MIMX8QX2/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX3/drivers/driver_reset.cmake
+++ b/devices/MIMX8QX3/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX4/drivers/driver_reset.cmake
+++ b/devices/MIMX8QX4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX5/drivers/driver_reset.cmake
+++ b/devices/MIMX8QX5/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX6/device_CMSIS.cmake
+++ b/devices/MIMX8QX6/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX6/device_startup.cmake
+++ b/devices/MIMX8QX6/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX6/device_system.cmake
+++ b/devices/MIMX8QX6/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX6/drivers/driver_clock.cmake
+++ b/devices/MIMX8QX6/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Driver clock; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX6/drivers/driver_memory.cmake
+++ b/devices/MIMX8QX6/drivers/driver_memory.cmake
@@ -1,5 +1,5 @@
 #Description: Memory Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_memory component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX6/drivers/driver_reset.cmake
+++ b/devices/MIMX8QX6/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8QX6/scfw_api/driver_scfw_api.cmake
+++ b/devices/MIMX8QX6/scfw_api/driver_scfw_api.cmake
@@ -1,5 +1,5 @@
 #Description: SCFW API Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_scfw_api component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8UX5/drivers/driver_reset.cmake
+++ b/devices/MIMX8UX5/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMX8UX6/drivers/driver_reset.cmake
+++ b/devices/MIMX8UX6/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1011/device_CMSIS.cmake
+++ b/devices/MIMXRT1011/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1011/device_startup.cmake
+++ b/devices/MIMXRT1011/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1011/device_system.cmake
+++ b/devices/MIMXRT1011/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1011/drivers/driver_clock.cmake
+++ b/devices/MIMXRT1011/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1011/drivers/driver_iomuxc.cmake
+++ b/devices/MIMXRT1011/drivers/driver_iomuxc.cmake
@@ -1,5 +1,5 @@
 #Description: IOMUXC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iomuxc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1011/drivers/driver_reset.cmake
+++ b/devices/MIMXRT1011/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1011/drivers/driver_soc_flexram_allocate.cmake
+++ b/devices/MIMXRT1011/drivers/driver_soc_flexram_allocate.cmake
@@ -1,5 +1,5 @@
 #Description: SOC FLEXRAM ALLOCATE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_soc_flexram_allocate component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1011/utilities/utility_shell.cmake
+++ b/devices/MIMXRT1011/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1011/xip/driver_xip_device.cmake
+++ b/devices/MIMXRT1011/xip/driver_xip_device.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Device Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_device component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/device_CMSIS.cmake
+++ b/devices/MIMXRT1015/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/device_startup.cmake
+++ b/devices/MIMXRT1015/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/device_system.cmake
+++ b/devices/MIMXRT1015/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/drivers/driver_clock.cmake
+++ b/devices/MIMXRT1015/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/drivers/driver_iomuxc.cmake
+++ b/devices/MIMXRT1015/drivers/driver_iomuxc.cmake
@@ -1,5 +1,5 @@
 #Description: IOMUXC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iomuxc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/drivers/driver_reset.cmake
+++ b/devices/MIMXRT1015/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/drivers/driver_romapi.cmake
+++ b/devices/MIMXRT1015/drivers/driver_romapi.cmake
@@ -1,5 +1,5 @@
 #Description: ROMAPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_romapi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/drivers/driver_soc_flexram_allocate.cmake
+++ b/devices/MIMXRT1015/drivers/driver_soc_flexram_allocate.cmake
@@ -1,5 +1,5 @@
 #Description: SOC FLEXRAM ALLOCATE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_soc_flexram_allocate component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/utilities/utility_shell.cmake
+++ b/devices/MIMXRT1015/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1015/xip/driver_xip_device.cmake
+++ b/devices/MIMXRT1015/xip/driver_xip_device.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Device Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_device component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/device_CMSIS.cmake
+++ b/devices/MIMXRT1021/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/device_startup.cmake
+++ b/devices/MIMXRT1021/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/device_system.cmake
+++ b/devices/MIMXRT1021/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/drivers/driver_clock.cmake
+++ b/devices/MIMXRT1021/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/drivers/driver_iomuxc.cmake
+++ b/devices/MIMXRT1021/drivers/driver_iomuxc.cmake
@@ -1,5 +1,5 @@
 #Description: IOMUXC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iomuxc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/drivers/driver_reset.cmake
+++ b/devices/MIMXRT1021/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/drivers/driver_romapi.cmake
+++ b/devices/MIMXRT1021/drivers/driver_romapi.cmake
@@ -1,5 +1,5 @@
 #Description: ROMAPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_romapi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/drivers/driver_soc_flexram_allocate.cmake
+++ b/devices/MIMXRT1021/drivers/driver_soc_flexram_allocate.cmake
@@ -1,5 +1,5 @@
 #Description: SOC FLEXRAM ALLOCATE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_soc_flexram_allocate component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/utilities/utility_shell.cmake
+++ b/devices/MIMXRT1021/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1021/xip/driver_xip_device.cmake
+++ b/devices/MIMXRT1021/xip/driver_xip_device.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Device Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_device component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/device_CMSIS.cmake
+++ b/devices/MIMXRT1024/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/device_startup.cmake
+++ b/devices/MIMXRT1024/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/device_system.cmake
+++ b/devices/MIMXRT1024/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/drivers/driver_clock.cmake
+++ b/devices/MIMXRT1024/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/drivers/driver_iomuxc.cmake
+++ b/devices/MIMXRT1024/drivers/driver_iomuxc.cmake
@@ -1,5 +1,5 @@
 #Description: IOMUXC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iomuxc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/drivers/driver_reset.cmake
+++ b/devices/MIMXRT1024/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/drivers/driver_romapi.cmake
+++ b/devices/MIMXRT1024/drivers/driver_romapi.cmake
@@ -1,5 +1,5 @@
 #Description: ROMAPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_romapi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/drivers/driver_soc_flexram_allocate.cmake
+++ b/devices/MIMXRT1024/drivers/driver_soc_flexram_allocate.cmake
@@ -1,5 +1,5 @@
 #Description: SOC FLEXRAM ALLOCATE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_soc_flexram_allocate component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/utilities/utility_shell.cmake
+++ b/devices/MIMXRT1024/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1024/xip/driver_xip_device.cmake
+++ b/devices/MIMXRT1024/xip/driver_xip_device.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Device Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_device component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1051/drivers/driver_reset.cmake
+++ b/devices/MIMXRT1051/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/device_CMSIS.cmake
+++ b/devices/MIMXRT1052/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/device_startup.cmake
+++ b/devices/MIMXRT1052/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/device_system.cmake
+++ b/devices/MIMXRT1052/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/drivers/driver_clock.cmake
+++ b/devices/MIMXRT1052/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/drivers/driver_iomuxc.cmake
+++ b/devices/MIMXRT1052/drivers/driver_iomuxc.cmake
@@ -1,5 +1,5 @@
 #Description: IOMUXC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iomuxc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/drivers/driver_reset.cmake
+++ b/devices/MIMXRT1052/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/drivers/driver_romapi.cmake
+++ b/devices/MIMXRT1052/drivers/driver_romapi.cmake
@@ -1,5 +1,5 @@
 #Description: ROMAPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_romapi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/drivers/driver_soc_flexram_allocate.cmake
+++ b/devices/MIMXRT1052/drivers/driver_soc_flexram_allocate.cmake
@@ -1,5 +1,5 @@
 #Description: SOC FLEXRAM ALLOCATE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_soc_flexram_allocate component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/utilities/utility_shell.cmake
+++ b/devices/MIMXRT1052/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1052/xip/driver_xip_device.cmake
+++ b/devices/MIMXRT1052/xip/driver_xip_device.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Device Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_device component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1061/drivers/driver_reset.cmake
+++ b/devices/MIMXRT1061/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/device_CMSIS.cmake
+++ b/devices/MIMXRT1062/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/device_startup.cmake
+++ b/devices/MIMXRT1062/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/device_system.cmake
+++ b/devices/MIMXRT1062/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/drivers/driver_clock.cmake
+++ b/devices/MIMXRT1062/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/drivers/driver_iomuxc.cmake
+++ b/devices/MIMXRT1062/drivers/driver_iomuxc.cmake
@@ -1,5 +1,5 @@
 #Description: IOMUXC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iomuxc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/drivers/driver_reset.cmake
+++ b/devices/MIMXRT1062/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/drivers/driver_romapi.cmake
+++ b/devices/MIMXRT1062/drivers/driver_romapi.cmake
@@ -1,5 +1,5 @@
 #Description: ROMAPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_romapi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/drivers/driver_soc_flexram_allocate.cmake
+++ b/devices/MIMXRT1062/drivers/driver_soc_flexram_allocate.cmake
@@ -1,5 +1,5 @@
 #Description: SOC FLEXRAM ALLOCATE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_soc_flexram_allocate component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/utilities/utility_shell.cmake
+++ b/devices/MIMXRT1062/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1062/xip/driver_xip_device.cmake
+++ b/devices/MIMXRT1062/xip/driver_xip_device.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Device Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_device component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/device_CMSIS.cmake
+++ b/devices/MIMXRT1064/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/device_startup.cmake
+++ b/devices/MIMXRT1064/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/device_system.cmake
+++ b/devices/MIMXRT1064/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/drivers/driver_clock.cmake
+++ b/devices/MIMXRT1064/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/drivers/driver_iomuxc.cmake
+++ b/devices/MIMXRT1064/drivers/driver_iomuxc.cmake
@@ -1,5 +1,5 @@
 #Description: IOMUXC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iomuxc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/drivers/driver_reset.cmake
+++ b/devices/MIMXRT1064/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/drivers/driver_romapi.cmake
+++ b/devices/MIMXRT1064/drivers/driver_romapi.cmake
@@ -1,5 +1,5 @@
 #Description: ROMAPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_romapi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/drivers/driver_soc_flexram_allocate.cmake
+++ b/devices/MIMXRT1064/drivers/driver_soc_flexram_allocate.cmake
@@ -1,5 +1,5 @@
 #Description: SOC FLEXRAM ALLOCATE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_soc_flexram_allocate component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/utilities/utility_shell.cmake
+++ b/devices/MIMXRT1064/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT1064/xip/driver_xip_device.cmake
+++ b/devices/MIMXRT1064/xip/driver_xip_device.cmake
@@ -1,5 +1,5 @@
 #Description: XIP Device Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xip_device component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT633S/drivers/driver_reset.cmake
+++ b/devices/MIMXRT633S/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT685S/device_CMSIS.cmake
+++ b/devices/MIMXRT685S/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT685S/device_startup.cmake
+++ b/devices/MIMXRT685S/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT685S/drivers/driver_clock.cmake
+++ b/devices/MIMXRT685S/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT685S/drivers/driver_inputmux_connections.cmake
+++ b/devices/MIMXRT685S/drivers/driver_inputmux_connections.cmake
@@ -1,5 +1,5 @@
 #Description: Inputmux_connections Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux_connections component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT685S/drivers/driver_power.cmake
+++ b/devices/MIMXRT685S/drivers/driver_power.cmake
@@ -1,5 +1,5 @@
 #Description: Driver power; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_power component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT685S/drivers/driver_reset.cmake
+++ b/devices/MIMXRT685S/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MIMXRT685S/utilities/utility_shell.cmake
+++ b/devices/MIMXRT685S/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK02F12810/drivers/driver_reset.cmake
+++ b/devices/MK02F12810/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK22F12810/drivers/driver_reset.cmake
+++ b/devices/MK22F12810/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK22F25612/drivers/driver_reset.cmake
+++ b/devices/MK22F25612/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK22F51212/device_CMSIS.cmake
+++ b/devices/MK22F51212/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK22F51212/device_startup.cmake
+++ b/devices/MK22F51212/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK22F51212/device_system.cmake
+++ b/devices/MK22F51212/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK22F51212/drivers/driver_clock.cmake
+++ b/devices/MK22F51212/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK22F51212/drivers/driver_reset.cmake
+++ b/devices/MK22F51212/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK22F51212/utilities/utility_notifier.cmake
+++ b/devices/MK22F51212/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK22F51212/utilities/utility_shell.cmake
+++ b/devices/MK22F51212/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK24F12/drivers/driver_reset.cmake
+++ b/devices/MK24F12/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK26F18/drivers/driver_reset.cmake
+++ b/devices/MK26F18/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK27FA15/drivers/driver_reset.cmake
+++ b/devices/MK27FA15/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK28FA15/device_CMSIS.cmake
+++ b/devices/MK28FA15/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK28FA15/device_startup.cmake
+++ b/devices/MK28FA15/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK28FA15/device_system.cmake
+++ b/devices/MK28FA15/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK28FA15/drivers/driver_clock.cmake
+++ b/devices/MK28FA15/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK28FA15/drivers/driver_reset.cmake
+++ b/devices/MK28FA15/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK28FA15/utilities/utility_notifier.cmake
+++ b/devices/MK28FA15/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK28FA15/utilities/utility_shell.cmake
+++ b/devices/MK28FA15/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK63F12/drivers/driver_reset.cmake
+++ b/devices/MK63F12/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK64F12/device_CMSIS.cmake
+++ b/devices/MK64F12/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK64F12/device_startup.cmake
+++ b/devices/MK64F12/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK64F12/device_system.cmake
+++ b/devices/MK64F12/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK64F12/drivers/driver_clock.cmake
+++ b/devices/MK64F12/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK64F12/drivers/driver_reset.cmake
+++ b/devices/MK64F12/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK64F12/utilities/utility_notifier.cmake
+++ b/devices/MK64F12/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK64F12/utilities/utility_shell.cmake
+++ b/devices/MK64F12/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK65F18/drivers/driver_reset.cmake
+++ b/devices/MK65F18/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK66F18/device_CMSIS.cmake
+++ b/devices/MK66F18/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK66F18/device_startup.cmake
+++ b/devices/MK66F18/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK66F18/device_system.cmake
+++ b/devices/MK66F18/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK66F18/drivers/driver_clock.cmake
+++ b/devices/MK66F18/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK66F18/drivers/driver_reset.cmake
+++ b/devices/MK66F18/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK66F18/utilities/utility_notifier.cmake
+++ b/devices/MK66F18/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MK66F18/utilities/utility_shell.cmake
+++ b/devices/MK66F18/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE02Z4/device_CMSIS.cmake
+++ b/devices/MKE02Z4/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE02Z4/device_startup.cmake
+++ b/devices/MKE02Z4/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE02Z4/device_system.cmake
+++ b/devices/MKE02Z4/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE02Z4/drivers/driver_clock.cmake
+++ b/devices/MKE02Z4/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE02Z4/drivers/driver_port_ke02.cmake
+++ b/devices/MKE02Z4/drivers/driver_port_ke02.cmake
@@ -1,5 +1,5 @@
 #Description: port Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_port_ke02 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE02Z4/drivers/driver_reset.cmake
+++ b/devices/MKE02Z4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE04Z1284/drivers/driver_reset.cmake
+++ b/devices/MKE04Z1284/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE04Z4/device_CMSIS.cmake
+++ b/devices/MKE04Z4/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE04Z4/device_startup.cmake
+++ b/devices/MKE04Z4/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE04Z4/device_system.cmake
+++ b/devices/MKE04Z4/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE04Z4/drivers/driver_clock.cmake
+++ b/devices/MKE04Z4/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE04Z4/drivers/driver_port_ke04.cmake
+++ b/devices/MKE04Z4/drivers/driver_port_ke04.cmake
@@ -1,5 +1,5 @@
 #Description: port Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_port_ke04 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE04Z4/drivers/driver_reset.cmake
+++ b/devices/MKE04Z4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE06Z4/device_CMSIS.cmake
+++ b/devices/MKE06Z4/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE06Z4/device_startup.cmake
+++ b/devices/MKE06Z4/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE06Z4/device_system.cmake
+++ b/devices/MKE06Z4/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE06Z4/drivers/driver_clock.cmake
+++ b/devices/MKE06Z4/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE06Z4/drivers/driver_port_ke06.cmake
+++ b/devices/MKE06Z4/drivers/driver_port_ke06.cmake
@@ -1,5 +1,5 @@
 #Description: port Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_port_ke06 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE06Z4/drivers/driver_reset.cmake
+++ b/devices/MKE06Z4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE14Z4/drivers/driver_reset.cmake
+++ b/devices/MKE14Z4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE14Z7/drivers/driver_reset.cmake
+++ b/devices/MKE14Z7/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE15Z4/drivers/driver_reset.cmake
+++ b/devices/MKE15Z4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE15Z7/device_CMSIS.cmake
+++ b/devices/MKE15Z7/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE15Z7/device_startup.cmake
+++ b/devices/MKE15Z7/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE15Z7/device_system.cmake
+++ b/devices/MKE15Z7/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE15Z7/drivers/driver_clock.cmake
+++ b/devices/MKE15Z7/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE15Z7/drivers/driver_reset.cmake
+++ b/devices/MKE15Z7/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE15Z7/utilities/utility_notifier.cmake
+++ b/devices/MKE15Z7/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE15Z7/utilities/utility_shell.cmake
+++ b/devices/MKE15Z7/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE16Z4/device_CMSIS.cmake
+++ b/devices/MKE16Z4/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE16Z4/device_startup.cmake
+++ b/devices/MKE16Z4/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE16Z4/device_system.cmake
+++ b/devices/MKE16Z4/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE16Z4/drivers/driver_clock.cmake
+++ b/devices/MKE16Z4/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE16Z4/drivers/driver_reset.cmake
+++ b/devices/MKE16Z4/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE16Z4/utilities/utility_notifier.cmake
+++ b/devices/MKE16Z4/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKE16Z4/utilities/utility_shell.cmake
+++ b/devices/MKE16Z4/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKL17Z644/drivers/driver_reset.cmake
+++ b/devices/MKL17Z644/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKL27Z644/device_CMSIS.cmake
+++ b/devices/MKL27Z644/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKL27Z644/device_startup.cmake
+++ b/devices/MKL27Z644/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKL27Z644/device_system.cmake
+++ b/devices/MKL27Z644/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKL27Z644/drivers/driver_clock.cmake
+++ b/devices/MKL27Z644/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKL27Z644/drivers/driver_reset.cmake
+++ b/devices/MKL27Z644/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKL27Z644/utilities/utility_notifier.cmake
+++ b/devices/MKL27Z644/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKL27Z644/utilities/utility_shell.cmake
+++ b/devices/MKL27Z644/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKM35Z7/device_CMSIS.cmake
+++ b/devices/MKM35Z7/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKM35Z7/device_startup.cmake
+++ b/devices/MKM35Z7/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKM35Z7/device_system.cmake
+++ b/devices/MKM35Z7/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKM35Z7/drivers/driver_clock.cmake
+++ b/devices/MKM35Z7/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKM35Z7/drivers/driver_reset.cmake
+++ b/devices/MKM35Z7/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKM35Z7/utilities/utility_notifier.cmake
+++ b/devices/MKM35Z7/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKM35Z7/utilities/utility_shell.cmake
+++ b/devices/MKM35Z7/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV10Z1287/drivers/driver_reset.cmake
+++ b/devices/MKV10Z1287/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV10Z7/drivers/driver_reset.cmake
+++ b/devices/MKV10Z7/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV11Z7/device_CMSIS.cmake
+++ b/devices/MKV11Z7/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV11Z7/device_startup.cmake
+++ b/devices/MKV11Z7/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV11Z7/device_system.cmake
+++ b/devices/MKV11Z7/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV11Z7/drivers/driver_clock.cmake
+++ b/devices/MKV11Z7/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV11Z7/drivers/driver_reset.cmake
+++ b/devices/MKV11Z7/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV11Z7/utilities/utility_notifier.cmake
+++ b/devices/MKV11Z7/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV11Z7/utilities/utility_shell.cmake
+++ b/devices/MKV11Z7/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV30F12810/drivers/driver_reset.cmake
+++ b/devices/MKV30F12810/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV31F12810/drivers/driver_reset.cmake
+++ b/devices/MKV31F12810/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV31F25612/drivers/driver_reset.cmake
+++ b/devices/MKV31F25612/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV31F51212/device_CMSIS.cmake
+++ b/devices/MKV31F51212/device_CMSIS.cmake
@@ -1,5 +1,5 @@
 #Description: device_CMSIS; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_CMSIS component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV31F51212/device_startup.cmake
+++ b/devices/MKV31F51212/device_startup.cmake
@@ -1,5 +1,5 @@
 #Description: device_startup; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_startup component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV31F51212/device_system.cmake
+++ b/devices/MKV31F51212/device_system.cmake
@@ -1,5 +1,5 @@
 #Description: device_system; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("device_system component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV31F51212/drivers/driver_clock.cmake
+++ b/devices/MKV31F51212/drivers/driver_clock.cmake
@@ -1,5 +1,5 @@
 #Description: Clock Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_clock component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV31F51212/drivers/driver_reset.cmake
+++ b/devices/MKV31F51212/drivers/driver_reset.cmake
@@ -1,5 +1,5 @@
 #Description: Reset Driver; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_reset component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV31F51212/utilities/utility_notifier.cmake
+++ b/devices/MKV31F51212/utilities/utility_notifier.cmake
@@ -1,5 +1,5 @@
 #Description: Utility notifier; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_notifier component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/devices/MKV31F51212/utilities/utility_shell.cmake
+++ b/devices/MKV31F51212/utilities/utility_shell.cmake
@@ -1,5 +1,5 @@
 #Description: Utility shell; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_shell component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/acmp/driver_acmp.cmake
+++ b/drivers/acmp/driver_acmp.cmake
@@ -1,5 +1,5 @@
 #Description: ACMP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_acmp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/acmp_1/driver_acmp_1.cmake
+++ b/drivers/acmp_1/driver_acmp_1.cmake
@@ -1,5 +1,5 @@
 #Description: ACMP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_acmp_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/adc12/driver_adc12.cmake
+++ b/drivers/adc12/driver_adc12.cmake
@@ -1,5 +1,5 @@
 #Description: ADC12 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_adc12 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/adc16/driver_adc16.cmake
+++ b/drivers/adc16/driver_adc16.cmake
@@ -1,5 +1,5 @@
 #Description: ADC16 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_adc16 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/adc_12b1msps_sar/driver_adc_12b1msps_sar.cmake
+++ b/drivers/adc_12b1msps_sar/driver_adc_12b1msps_sar.cmake
@@ -1,5 +1,5 @@
 #Description: ADC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_adc_12b1msps_sar component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/adc_5v12b_ll18_015/driver_adc_5v12b_ll18_015.cmake
+++ b/drivers/adc_5v12b_ll18_015/driver_adc_5v12b_ll18_015.cmake
@@ -1,5 +1,5 @@
 #Description: ADC12 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_adc_5v12b_ll18_015 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/adc_etc/driver_adc_etc.cmake
+++ b/drivers/adc_etc/driver_adc_etc.cmake
@@ -1,5 +1,5 @@
 #Description: ADC_ETC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_adc_etc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/aes/driver_aes.cmake
+++ b/drivers/aes/driver_aes.cmake
@@ -1,5 +1,5 @@
 #Description: AES Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_aes component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/afe/driver_afe.cmake
+++ b/drivers/afe/driver_afe.cmake
@@ -1,5 +1,5 @@
 #Description: AFE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_afe component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/anactrl/driver_anactrl.cmake
+++ b/drivers/anactrl/driver_anactrl.cmake
@@ -1,5 +1,5 @@
 #Description: anactrl Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_anactrl component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/aoi/driver_aoi.cmake
+++ b/drivers/aoi/driver_aoi.cmake
@@ -1,5 +1,5 @@
 #Description: AOI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_aoi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/asmc/driver_asmc.cmake
+++ b/drivers/asmc/driver_asmc.cmake
@@ -1,5 +1,5 @@
 #Description: ASMC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_asmc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/bee/driver_bee.cmake
+++ b/drivers/bee/driver_bee.cmake
@@ -1,5 +1,5 @@
 #Description: BEE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_bee component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/cache/armv7-m7/driver_cache_armv7_m7.cmake
+++ b/drivers/cache/armv7-m7/driver_cache_armv7_m7.cmake
@@ -1,5 +1,5 @@
 #Description: CACHE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cache_armv7_m7 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/cache/cache64/driver_cache_cache64.cmake
+++ b/drivers/cache/cache64/driver_cache_cache64.cmake
@@ -1,5 +1,5 @@
 #Description: CACHE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cache_cache64 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/cache/lmem/driver_cache_lmem.cmake
+++ b/drivers/cache/lmem/driver_cache_lmem.cmake
@@ -1,5 +1,5 @@
 #Description: CACHE LMEM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cache_lmem component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/capt/driver_capt.cmake
+++ b/drivers/capt/driver_capt.cmake
@@ -1,5 +1,5 @@
 #Description: CAPT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_capt component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/casper/driver_casper.cmake
+++ b/drivers/casper/driver_casper.cmake
@@ -1,5 +1,5 @@
 #Description: CASPER Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_casper component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/cau3/driver_cau3.cmake
+++ b/drivers/cau3/driver_cau3.cmake
@@ -1,5 +1,5 @@
 #Description: CAU3 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cau3 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ci_pi/driver_ci_pi.cmake
+++ b/drivers/ci_pi/driver_ci_pi.cmake
@@ -1,5 +1,5 @@
 #Description: CI_PI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ci_pi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/cmp/driver_cmp.cmake
+++ b/drivers/cmp/driver_cmp.cmake
@@ -1,5 +1,5 @@
 #Description: CMP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cmp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/cmp_1/driver_cmp_1.cmake
+++ b/drivers/cmp_1/driver_cmp_1.cmake
@@ -1,5 +1,5 @@
 #Description: cmp_1 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cmp_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/cmt/driver_cmt.cmake
+++ b/drivers/cmt/driver_cmt.cmake
@@ -1,5 +1,5 @@
 #Description: CMT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cmt component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/common/driver_common.cmake
+++ b/drivers/common/driver_common.cmake
@@ -1,5 +1,5 @@
 #Description: Common Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/cop/driver_cop.cmake
+++ b/drivers/cop/driver_cop.cmake
@@ -1,5 +1,5 @@
 #Description: COP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cop component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/crc/driver_crc.cmake
+++ b/drivers/crc/driver_crc.cmake
@@ -1,5 +1,5 @@
 #Description: CRC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_crc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/csi/driver_csi.cmake
+++ b/drivers/csi/driver_csi.cmake
@@ -1,5 +1,5 @@
 #Description: CSI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_csi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ctimer/driver_ctimer.cmake
+++ b/drivers/ctimer/driver_ctimer.cmake
@@ -1,5 +1,5 @@
 #Description: CTimer Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ctimer component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/cwt/driver_cwt.cmake
+++ b/drivers/cwt/driver_cwt.cmake
@@ -1,5 +1,5 @@
 #Description: CWT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_cwt component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dac/driver_dac.cmake
+++ b/drivers/dac/driver_dac.cmake
@@ -1,5 +1,5 @@
 #Description: DAC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dac component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dac12/driver_dac12.cmake
+++ b/drivers/dac12/driver_dac12.cmake
@@ -1,5 +1,5 @@
 #Description: DAC12 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dac12 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dac_1/driver_dac_1.cmake
+++ b/drivers/dac_1/driver_dac_1.cmake
@@ -1,5 +1,5 @@
 #Description: DAC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dac_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dcdc_1/driver_dcdc_1.cmake
+++ b/drivers/dcdc_1/driver_dcdc_1.cmake
@@ -1,5 +1,5 @@
 #Description: DCDC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dcdc_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dcp/driver_dcp.cmake
+++ b/drivers/dcp/driver_dcp.cmake
@@ -1,5 +1,5 @@
 #Description: DCP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dcp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dma/driver_dma.cmake
+++ b/drivers/dma/driver_dma.cmake
@@ -1,5 +1,5 @@
 #Description: DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dma3/driver_dma3.cmake
+++ b/drivers/dma3/driver_dma3.cmake
@@ -1,5 +1,5 @@
 #Description: EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dma3 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dmamux/driver_dmamux.cmake
+++ b/drivers/dmamux/driver_dmamux.cmake
@@ -1,5 +1,5 @@
 #Description: DMAMUX Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dmamux component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dmic/driver_dmic.cmake
+++ b/drivers/dmic/driver_dmic.cmake
@@ -1,5 +1,5 @@
 #Description: DMIC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dmic component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dmic/driver_dmic_dma.cmake
+++ b/drivers/dmic/driver_dmic_dma.cmake
@@ -1,5 +1,5 @@
 #Description: DMIC DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dmic_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dmic/driver_dmic_hwvad.cmake
+++ b/drivers/dmic/driver_dmic_hwvad.cmake
@@ -1,5 +1,5 @@
 #Description: DMIC HWVAD Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dmic_hwvad component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dpr/driver_dpr.cmake
+++ b/drivers/dpr/driver_dpr.cmake
@@ -1,5 +1,5 @@
 #Description: DPR Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dpr component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dpu/driver_dpu.cmake
+++ b/drivers/dpu/driver_dpu.cmake
@@ -1,5 +1,5 @@
 #Description: DPU Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dpu component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dpu_irqsteer/driver_dpu_irqsteer.cmake
+++ b/drivers/dpu_irqsteer/driver_dpu_irqsteer.cmake
@@ -1,5 +1,5 @@
 #Description: DPU IRQSTEER Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dpu_irqsteer component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dspi/driver_dspi.cmake
+++ b/drivers/dspi/driver_dspi.cmake
@@ -1,5 +1,5 @@
 #Description: DSPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dspi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dspi/driver_dspi_edma.cmake
+++ b/drivers/dspi/driver_dspi_edma.cmake
@@ -1,5 +1,5 @@
 #Description: DSPI_EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dspi_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/dspi/driver_dspi_freertos.cmake
+++ b/drivers/dspi/driver_dspi_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: DSPI Freertos Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_dspi_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/easrc/driver_easrc.cmake
+++ b/drivers/easrc/driver_easrc.cmake
@@ -1,5 +1,5 @@
 #Description: asrc Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_easrc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/easrc/driver_easrc_sdma.cmake
+++ b/drivers/easrc/driver_easrc_sdma.cmake
@@ -1,5 +1,5 @@
 #Description: asrc_m2m_sdma Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_easrc_sdma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ecspi/driver_ecspi.cmake
+++ b/drivers/ecspi/driver_ecspi.cmake
@@ -1,5 +1,5 @@
 #Description: ECSPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ecspi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ecspi/driver_ecspi_freertos.cmake
+++ b/drivers/ecspi/driver_ecspi_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: ECSPI Freertos Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ecspi_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/edma/driver_edma.cmake
+++ b/drivers/edma/driver_edma.cmake
@@ -1,5 +1,5 @@
 #Description: EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/eeprom/driver_eeprom.cmake
+++ b/drivers/eeprom/driver_eeprom.cmake
@@ -1,5 +1,5 @@
 #Description: eeprom Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_eeprom component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/elcdif/driver_elcdif.cmake
+++ b/drivers/elcdif/driver_elcdif.cmake
@@ -1,5 +1,5 @@
 #Description: ELCDIF Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_elcdif component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/emc/driver_emc.cmake
+++ b/drivers/emc/driver_emc.cmake
@@ -1,5 +1,5 @@
 #Description: EMC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_emc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/enc/driver_enc.cmake
+++ b/drivers/enc/driver_enc.cmake
@@ -1,5 +1,5 @@
 #Description: ENC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_enc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/enet/driver_enet.cmake
+++ b/drivers/enet/driver_enet.cmake
@@ -1,5 +1,5 @@
 #Description: ENET Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_enet component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/esai/driver_esai.cmake
+++ b/drivers/esai/driver_esai.cmake
@@ -1,5 +1,5 @@
 #Description: ESAI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_esai component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/esai/driver_esai_edma.cmake
+++ b/drivers/esai/driver_esai_edma.cmake
@@ -1,5 +1,5 @@
 #Description: ESAI EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_esai_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ewm/driver_ewm.cmake
+++ b/drivers/ewm/driver_ewm.cmake
@@ -1,5 +1,5 @@
 #Description: EWM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ewm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flash/driver_flash.cmake
+++ b/drivers/flash/driver_flash.cmake
@@ -1,5 +1,5 @@
 #Description: Flash Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flash component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flash_ftmr/driver_flash_ftmr.cmake
+++ b/drivers/flash_ftmr/driver_flash_ftmr.cmake
@@ -1,5 +1,5 @@
 #Description: Flash Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flash_ftmr component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flashiap/driver_flashiap.cmake
+++ b/drivers/flashiap/driver_flashiap.cmake
@@ -1,5 +1,5 @@
 #Description: FLASHIAP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flashiap component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcan/driver_flexcan.cmake
+++ b/drivers/flexcan/driver_flexcan.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCAN Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcan component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcan/driver_flexcan_edma.cmake
+++ b/drivers/flexcan/driver_flexcan_edma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCAN EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcan_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm.cmake
+++ b/drivers/flexcomm/driver_flexcomm.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_i2c.cmake
+++ b/drivers/flexcomm/driver_flexcomm_i2c.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM I2C Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_i2c_dma.cmake
+++ b/drivers/flexcomm/driver_flexcomm_i2c_dma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM I2C DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_i2c_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_i2c_freertos.cmake
+++ b/drivers/flexcomm/driver_flexcomm_i2c_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM I2C FREERTOS Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_i2c_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_i2s.cmake
+++ b/drivers/flexcomm/driver_flexcomm_i2s.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM I2S Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_i2s component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_i2s_dma.cmake
+++ b/drivers/flexcomm/driver_flexcomm_i2s_dma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM I2S DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_i2s_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_spi.cmake
+++ b/drivers/flexcomm/driver_flexcomm_spi.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM SPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_spi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_spi_dma.cmake
+++ b/drivers/flexcomm/driver_flexcomm_spi_dma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM SPI DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_spi_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_spi_freertos.cmake
+++ b/drivers/flexcomm/driver_flexcomm_spi_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM SPI FREERTOS Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_spi_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_usart.cmake
+++ b/drivers/flexcomm/driver_flexcomm_usart.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM USART Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_usart component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_usart_dma.cmake
+++ b/drivers/flexcomm/driver_flexcomm_usart_dma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM USART DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_usart_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexcomm/driver_flexcomm_usart_freertos.cmake
+++ b/drivers/flexcomm/driver_flexcomm_usart_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXCOMM USART FREERTOS Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexcomm_usart_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio.cmake
+++ b/drivers/flexio/driver_flexio.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_i2c_master.cmake
+++ b/drivers/flexio/driver_flexio_i2c_master.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO I2C Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_i2c_master component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_i2s.cmake
+++ b/drivers/flexio/driver_flexio_i2s.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO I2S Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_i2s component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_i2s_edma.cmake
+++ b/drivers/flexio/driver_flexio_i2s_edma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO I2S EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_i2s_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_mculcd.cmake
+++ b/drivers/flexio/driver_flexio_mculcd.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO MCULCD Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_mculcd component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_mculcd_edma.cmake
+++ b/drivers/flexio/driver_flexio_mculcd_edma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO MCULCD EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_mculcd_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_spi.cmake
+++ b/drivers/flexio/driver_flexio_spi.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO SPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_spi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_spi_dma.cmake
+++ b/drivers/flexio/driver_flexio_spi_dma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO SPI DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_spi_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_spi_edma.cmake
+++ b/drivers/flexio/driver_flexio_spi_edma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO SPI EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_spi_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_uart.cmake
+++ b/drivers/flexio/driver_flexio_uart.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO UART Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_uart component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_uart_dma.cmake
+++ b/drivers/flexio/driver_flexio_uart_dma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO UART DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_uart_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexio/driver_flexio_uart_edma.cmake
+++ b/drivers/flexio/driver_flexio_uart_edma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXIO UART EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexio_uart_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexram/driver_flexram.cmake
+++ b/drivers/flexram/driver_flexram.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXRAM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexram component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexspi/driver_flexspi.cmake
+++ b/drivers/flexspi/driver_flexspi.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXSPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexspi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexspi/driver_flexspi_dma.cmake
+++ b/drivers/flexspi/driver_flexspi_dma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXSPI DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexspi_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/flexspi/driver_flexspi_edma.cmake
+++ b/drivers/flexspi/driver_flexspi_edma.cmake
@@ -1,5 +1,5 @@
 #Description: FLEXSPI EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_flexspi_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/fmc/driver_fmc.cmake
+++ b/drivers/fmc/driver_fmc.cmake
@@ -1,5 +1,5 @@
 #Description: fmc Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_fmc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/fmeas/driver_fmeas.cmake
+++ b/drivers/fmeas/driver_fmeas.cmake
@@ -1,5 +1,5 @@
 #Description: FMEAS Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_fmeas component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ftm/driver_ftm.cmake
+++ b/drivers/ftm/driver_ftm.cmake
@@ -1,5 +1,5 @@
 #Description: FTM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ftm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/gint/driver_gint.cmake
+++ b/drivers/gint/driver_gint.cmake
@@ -1,5 +1,5 @@
 #Description: GINT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_gint component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/gpc_1/driver_gpc_1.cmake
+++ b/drivers/gpc_1/driver_gpc_1.cmake
@@ -1,5 +1,5 @@
 #Description: GPC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_gpc_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/gpc_2/driver_gpc_2.cmake
+++ b/drivers/gpc_2/driver_gpc_2.cmake
@@ -1,5 +1,5 @@
 #Description: GPC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_gpc_2 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/gpio/driver_gpio.cmake
+++ b/drivers/gpio/driver_gpio.cmake
@@ -1,5 +1,5 @@
 #Description: GPIO Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_gpio component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/gpio_1/driver_gpio_1.cmake
+++ b/drivers/gpio_1/driver_gpio_1.cmake
@@ -1,5 +1,5 @@
 #Description: GPIO Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_gpio_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/gpt/driver_gpt.cmake
+++ b/drivers/gpt/driver_gpt.cmake
@@ -1,5 +1,5 @@
 #Description: GPT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_gpt component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/hashcrypt/driver_hashcrypt.cmake
+++ b/drivers/hashcrypt/driver_hashcrypt.cmake
@@ -1,5 +1,5 @@
 #Description: Hashcrypt Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_hashcrypt component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/i2c/driver_i2c.cmake
+++ b/drivers/i2c/driver_i2c.cmake
@@ -1,5 +1,5 @@
 #Description: I2C Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/i2c/driver_i2c_dma.cmake
+++ b/drivers/i2c/driver_i2c_dma.cmake
@@ -1,5 +1,5 @@
 #Description: I2C DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_i2c_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/i2c/driver_i2c_edma.cmake
+++ b/drivers/i2c/driver_i2c_edma.cmake
@@ -1,5 +1,5 @@
 #Description: I2C EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_i2c_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/i2c/driver_i2c_freertos.cmake
+++ b/drivers/i2c/driver_i2c_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: I2C FREERTOS Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_i2c_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/i3c/driver_i3c.cmake
+++ b/drivers/i3c/driver_i3c.cmake
@@ -1,5 +1,5 @@
 #Description: I3C Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_i3c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/iap/driver_iap.cmake
+++ b/drivers/iap/driver_iap.cmake
@@ -1,5 +1,5 @@
 #Description: IAP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iap component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/iap1/driver_iap1.cmake
+++ b/drivers/iap1/driver_iap1.cmake
@@ -1,5 +1,5 @@
 #Description: IAP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iap1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/igpio/driver_igpio.cmake
+++ b/drivers/igpio/driver_igpio.cmake
@@ -1,5 +1,5 @@
 #Description: igpio; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_igpio component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ii2c/driver_ii2c.cmake
+++ b/drivers/ii2c/driver_ii2c.cmake
@@ -1,5 +1,5 @@
 #Description: I2C Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ii2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ii2c/driver_ii2c_freertos.cmake
+++ b/drivers/ii2c/driver_ii2c_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: I2C Freertos Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ii2c_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/inputmux/driver_inputmux.cmake
+++ b/drivers/inputmux/driver_inputmux.cmake
@@ -1,5 +1,5 @@
 #Description: INPUTMUX Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_inputmux component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/intmux/driver_intmux.cmake
+++ b/drivers/intmux/driver_intmux.cmake
@@ -1,5 +1,5 @@
 #Description: INTMUX Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_intmux component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ipwm/driver_ipwm.cmake
+++ b/drivers/ipwm/driver_ipwm.cmake
@@ -1,5 +1,5 @@
 #Description: PWM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ipwm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/irq/driver_irq.cmake
+++ b/drivers/irq/driver_irq.cmake
@@ -1,5 +1,5 @@
 #Description: IRQ Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_irq component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/irqsteer/driver_irqsteer.cmake
+++ b/drivers/irqsteer/driver_irqsteer.cmake
@@ -1,5 +1,5 @@
 #Description: IRQSTEER Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_irqsteer component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/irtc/driver_irtc.cmake
+++ b/drivers/irtc/driver_irtc.cmake
@@ -1,5 +1,5 @@
 #Description: IRTC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_irtc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/isi/driver_isi.cmake
+++ b/drivers/isi/driver_isi.cmake
@@ -1,5 +1,5 @@
 #Description: ISI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_isi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/iuart/driver_iuart.cmake
+++ b/drivers/iuart/driver_iuart.cmake
@@ -1,5 +1,5 @@
 #Description: IUART Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iuart component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/iuart/driver_iuart_freertos.cmake
+++ b/drivers/iuart/driver_iuart_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: IUART Freertos Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iuart_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/iuart/driver_iuart_sdma.cmake
+++ b/drivers/iuart/driver_iuart_sdma.cmake
@@ -1,5 +1,5 @@
 #Description: IUART SDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_iuart_sdma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/kbi/driver_kbi.cmake
+++ b/drivers/kbi/driver_kbi.cmake
@@ -1,5 +1,5 @@
 #Description: KBI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_kbi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/kpp/driver_kpp.cmake
+++ b/drivers/kpp/driver_kpp.cmake
@@ -1,5 +1,5 @@
 #Description: KPP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_kpp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ldb/driver_ldb.cmake
+++ b/drivers/ldb/driver_ldb.cmake
@@ -1,5 +1,5 @@
 #Description: LDB Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ldb component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ldb_combo_phy/driver_ldb_combo_phy.cmake
+++ b/drivers/ldb_combo_phy/driver_ldb_combo_phy.cmake
@@ -1,5 +1,5 @@
 #Description: LDB Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ldb_combo_phy component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/llwu/driver_llwu.cmake
+++ b/drivers/llwu/driver_llwu.cmake
@@ -1,5 +1,5 @@
 #Description: LLWU Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_llwu component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpadc/driver_lpadc.cmake
+++ b/drivers/lpadc/driver_lpadc.cmake
@@ -1,5 +1,5 @@
 #Description: LPADC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpadc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_acomp/driver_lpc_acomp.cmake
+++ b/drivers/lpc_acomp/driver_lpc_acomp.cmake
@@ -1,5 +1,5 @@
 #Description: LPC_ACOMP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_acomp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_adc/driver_lpc_adc.cmake
+++ b/drivers/lpc_adc/driver_lpc_adc.cmake
@@ -1,5 +1,5 @@
 #Description: ADC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_adc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_crc/driver_lpc_crc.cmake
+++ b/drivers/lpc_crc/driver_lpc_crc.cmake
@@ -1,5 +1,5 @@
 #Description: CRC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_crc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_dac/driver_lpc_dac.cmake
+++ b/drivers/lpc_dac/driver_lpc_dac.cmake
@@ -1,5 +1,5 @@
 #Description: DAC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_dac component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_dma/driver_lpc_dma.cmake
+++ b/drivers/lpc_dma/driver_lpc_dma.cmake
@@ -1,5 +1,5 @@
 #Description: DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_enet/driver_lpc_enet.cmake
+++ b/drivers/lpc_enet/driver_lpc_enet.cmake
@@ -1,5 +1,5 @@
 #Description: enet Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_enet component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_gpio/driver_lpc_gpio.cmake
+++ b/drivers/lpc_gpio/driver_lpc_gpio.cmake
@@ -1,5 +1,5 @@
 #Description: GPIO Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_gpio component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_i2c/driver_lpc_i2c.cmake
+++ b/drivers/lpc_i2c/driver_lpc_i2c.cmake
@@ -1,5 +1,5 @@
 #Description: I2C Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_i2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_iocon/driver_lpc_iocon.cmake
+++ b/drivers/lpc_iocon/driver_lpc_iocon.cmake
@@ -1,5 +1,5 @@
 #Description: IOCON Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_iocon component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_iocon_lite/driver_lpc_iocon_lite.cmake
+++ b/drivers/lpc_iocon_lite/driver_lpc_iocon_lite.cmake
@@ -1,5 +1,5 @@
 #Description: IOCON Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_iocon_lite component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_iopctl/driver_lpc_iopctl.cmake
+++ b/drivers/lpc_iopctl/driver_lpc_iopctl.cmake
@@ -1,5 +1,5 @@
 #Description: iopctl Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_iopctl component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_lcdc/driver_lpc_lcdc.cmake
+++ b/drivers/lpc_lcdc/driver_lpc_lcdc.cmake
@@ -1,5 +1,5 @@
 #Description: LCDC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_lcdc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_minispi/driver_lpc_minispi.cmake
+++ b/drivers/lpc_minispi/driver_lpc_minispi.cmake
@@ -1,5 +1,5 @@
 #Description: SPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_minispi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_miniusart/driver_lpc_miniusart.cmake
+++ b/drivers/lpc_miniusart/driver_lpc_miniusart.cmake
@@ -1,5 +1,5 @@
 #Description: Usart Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_miniusart component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_rit/driver_rit.cmake
+++ b/drivers/lpc_rit/driver_rit.cmake
@@ -1,5 +1,5 @@
 #Description: RIT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rit component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpc_rtc/driver_lpc_rtc.cmake
+++ b/drivers/lpc_rtc/driver_lpc_rtc.cmake
@@ -1,5 +1,5 @@
 #Description: RTC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpc_rtc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpcmp/driver_lpcmp.cmake
+++ b/drivers/lpcmp/driver_lpcmp.cmake
@@ -1,5 +1,5 @@
 #Description: LPCMP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpcmp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpi2c/driver_lpi2c.cmake
+++ b/drivers/lpi2c/driver_lpi2c.cmake
@@ -1,5 +1,5 @@
 #Description: LPI2C Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpi2c component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpi2c/driver_lpi2c_edma.cmake
+++ b/drivers/lpi2c/driver_lpi2c_edma.cmake
@@ -1,5 +1,5 @@
 #Description: LPI2C Edma Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpi2c_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpi2c/driver_lpi2c_freertos.cmake
+++ b/drivers/lpi2c/driver_lpi2c_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: LPI2C Freerto Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpi2c_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpit/driver_lpit.cmake
+++ b/drivers/lpit/driver_lpit.cmake
@@ -1,5 +1,5 @@
 #Description: LPIT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpit component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpspi/driver_lpspi.cmake
+++ b/drivers/lpspi/driver_lpspi.cmake
@@ -1,5 +1,5 @@
 #Description: LPSPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpspi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpspi/driver_lpspi_edma.cmake
+++ b/drivers/lpspi/driver_lpspi_edma.cmake
@@ -1,5 +1,5 @@
 #Description: LPSPI Edma Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpspi_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpspi/driver_lpspi_freertos.cmake
+++ b/drivers/lpspi/driver_lpspi_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: LPSPI Freertos Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpspi_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lptmr/driver_lptmr.cmake
+++ b/drivers/lptmr/driver_lptmr.cmake
@@ -1,5 +1,5 @@
 #Description: LPTMR Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lptmr component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpuart/driver_lpuart.cmake
+++ b/drivers/lpuart/driver_lpuart.cmake
@@ -1,5 +1,5 @@
 #Description: LPUART Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpuart component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpuart/driver_lpuart_dma.cmake
+++ b/drivers/lpuart/driver_lpuart_dma.cmake
@@ -1,5 +1,5 @@
 #Description: LPUART DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpuart_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpuart/driver_lpuart_edma.cmake
+++ b/drivers/lpuart/driver_lpuart_edma.cmake
@@ -1,5 +1,5 @@
 #Description: LPUART Edma Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpuart_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/lpuart/driver_lpuart_freertos.cmake
+++ b/drivers/lpuart/driver_lpuart_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: LPUART Freertos Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_lpuart_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ltc/driver_ltc.cmake
+++ b/drivers/ltc/driver_ltc.cmake
@@ -1,5 +1,5 @@
 #Description: LTC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ltc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ltc/driver_ltc_edma.cmake
+++ b/drivers/ltc/driver_ltc_edma.cmake
@@ -1,5 +1,5 @@
 #Description: LTC EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ltc_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/mailbox/driver_mailbox.cmake
+++ b/drivers/mailbox/driver_mailbox.cmake
@@ -1,5 +1,5 @@
 #Description: MAILBOX Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mailbox component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/mcan/driver_mcan.cmake
+++ b/drivers/mcan/driver_mcan.cmake
@@ -1,5 +1,5 @@
 #Description: MCAN Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mcan component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/mipi_csi2rx/driver_mipi_csi2rx.cmake
+++ b/drivers/mipi_csi2rx/driver_mipi_csi2rx.cmake
@@ -1,5 +1,5 @@
 #Description: MIPI CSI2RX Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mipi_csi2rx component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/mipi_dsi/driver_mipi_dsi.cmake
+++ b/drivers/mipi_dsi/driver_mipi_dsi.cmake
@@ -1,5 +1,5 @@
 #Description: MIPI DSI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mipi_dsi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/mmau/driver_mmau.cmake
+++ b/drivers/mmau/driver_mmau.cmake
@@ -1,5 +1,5 @@
 #Description: MMAU Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mmau component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/mmdvsq/driver_mmdvsq.cmake
+++ b/drivers/mmdvsq/driver_mmdvsq.cmake
@@ -1,5 +1,5 @@
 #Description: MMDVSQ Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mmdvsq component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/mrt/driver_mrt.cmake
+++ b/drivers/mrt/driver_mrt.cmake
@@ -1,5 +1,5 @@
 #Description: MRT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mrt component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/mscan/driver_mscan.cmake
+++ b/drivers/mscan/driver_mscan.cmake
@@ -1,5 +1,5 @@
 #Description: MSCAN Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mscan component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/msmc/driver_msmc.cmake
+++ b/drivers/msmc/driver_msmc.cmake
@@ -1,5 +1,5 @@
 #Description: MSMC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_msmc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/mu/driver_mu.cmake
+++ b/drivers/mu/driver_mu.cmake
@@ -1,5 +1,5 @@
 #Description: MU Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_mu component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ocotp/driver_ocotp.cmake
+++ b/drivers/ocotp/driver_ocotp.cmake
@@ -1,5 +1,5 @@
 #Description: OCOTP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ocotp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/ostimer/driver_ostimer.cmake
+++ b/drivers/ostimer/driver_ostimer.cmake
@@ -1,5 +1,5 @@
 #Description: OSTimer Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_ostimer component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/otfad/driver_otfad.cmake
+++ b/drivers/otfad/driver_otfad.cmake
@@ -1,5 +1,5 @@
 #Description: OTFAD Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_otfad component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/otp/driver_otp.cmake
+++ b/drivers/otp/driver_otp.cmake
@@ -1,5 +1,5 @@
 #Description: OTP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_otp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pdb/driver_pdb.cmake
+++ b/drivers/pdb/driver_pdb.cmake
@@ -1,5 +1,5 @@
 #Description: PDB Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pdb component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pdm/driver_pdm.cmake
+++ b/drivers/pdm/driver_pdm.cmake
@@ -1,5 +1,5 @@
 #Description: PDM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pdm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pdm/driver_pdm_sdma.cmake
+++ b/drivers/pdm/driver_pdm_sdma.cmake
@@ -1,5 +1,5 @@
 #Description: PDM SDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pdm_sdma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pint/driver_pint.cmake
+++ b/drivers/pint/driver_pint.cmake
@@ -1,5 +1,5 @@
 #Description: PINT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pint component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pit/driver_pit.cmake
+++ b/drivers/pit/driver_pit.cmake
@@ -1,5 +1,5 @@
 #Description: PIT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pit component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/plu/driver_plu.cmake
+++ b/drivers/plu/driver_plu.cmake
@@ -1,5 +1,5 @@
 #Description: PLU Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_plu component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pmc/driver_pmc.cmake
+++ b/drivers/pmc/driver_pmc.cmake
@@ -1,5 +1,5 @@
 #Description: PMC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pmc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pmc0/driver_pmc0.cmake
+++ b/drivers/pmc0/driver_pmc0.cmake
@@ -1,5 +1,5 @@
 #Description: PMC0 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pmc0 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/port/driver_port.cmake
+++ b/drivers/port/driver_port.cmake
@@ -1,5 +1,5 @@
 #Description: PORT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_port component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/powerquad/driver_powerquad.cmake
+++ b/drivers/powerquad/driver_powerquad.cmake
@@ -1,5 +1,5 @@
 #Description: POWERQUAD Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_powerquad component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/prg/driver_prg.cmake
+++ b/drivers/prg/driver_prg.cmake
@@ -1,5 +1,5 @@
 #Description: PRG Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_prg component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/prince/driver_prince.cmake
+++ b/drivers/prince/driver_prince.cmake
@@ -1,5 +1,5 @@
 #Description: PRINCE Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_prince component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/puf/driver_puf.cmake
+++ b/drivers/puf/driver_puf.cmake
@@ -1,5 +1,5 @@
 #Description: PUF Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_puf component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pwm/driver_pwm.cmake
+++ b/drivers/pwm/driver_pwm.cmake
@@ -1,5 +1,5 @@
 #Description: PWM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pwm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pwt/driver_pwt.cmake
+++ b/drivers/pwt/driver_pwt.cmake
@@ -1,5 +1,5 @@
 #Description: PWT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pwt component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pwt_1/driver_pwt_1.cmake
+++ b/drivers/pwt_1/driver_pwt_1.cmake
@@ -1,5 +1,5 @@
 #Description: PWT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pwt_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/pxp/driver_pxp.cmake
+++ b/drivers/pxp/driver_pxp.cmake
@@ -1,5 +1,5 @@
 #Description: PXP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_pxp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/qspi/driver_qspi.cmake
+++ b/drivers/qspi/driver_qspi.cmake
@@ -1,5 +1,5 @@
 #Description: QSPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_qspi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/qspi/driver_qspi_edma.cmake
+++ b/drivers/qspi/driver_qspi_edma.cmake
@@ -1,5 +1,5 @@
 #Description: QSPI EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_qspi_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/qtmr_1/driver_qtmr_1.cmake
+++ b/drivers/qtmr_1/driver_qtmr_1.cmake
@@ -1,5 +1,5 @@
 #Description: QTMR Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_qtmr_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/qtmr_2/driver_qtmr_2.cmake
+++ b/drivers/qtmr_2/driver_qtmr_2.cmake
@@ -1,5 +1,5 @@
 #Description: QTMR_2 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_qtmr_2 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rcm/driver_rcm.cmake
+++ b/drivers/rcm/driver_rcm.cmake
@@ -1,5 +1,5 @@
 #Description: RCM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rcm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rdc/driver_rdc.cmake
+++ b/drivers/rdc/driver_rdc.cmake
@@ -1,5 +1,5 @@
 #Description: RDC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rdc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rdc_sema42/driver_rdc_sema42.cmake
+++ b/drivers/rdc_sema42/driver_rdc_sema42.cmake
@@ -1,5 +1,5 @@
 #Description: RDC SEMA42 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rdc_sema42 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rgpio/driver_rgpio.cmake
+++ b/drivers/rgpio/driver_rgpio.cmake
@@ -1,5 +1,5 @@
 #Description: RGPIO Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rgpio component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rng/driver_rng.cmake
+++ b/drivers/rng/driver_rng.cmake
@@ -1,5 +1,5 @@
 #Description: RNG Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rng component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rng_1/driver_rng_1.cmake
+++ b/drivers/rng_1/driver_rng_1.cmake
@@ -1,5 +1,5 @@
 #Description: RNG Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rng_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rnga/driver_rnga.cmake
+++ b/drivers/rnga/driver_rnga.cmake
@@ -1,5 +1,5 @@
 #Description: RNGA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rnga component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rtc/driver_rtc.cmake
+++ b/drivers/rtc/driver_rtc.cmake
@@ -1,5 +1,5 @@
 #Description: RTC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rtc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rtc_1/driver_rtc_1.cmake
+++ b/drivers/rtc_1/driver_rtc_1.cmake
@@ -1,5 +1,5 @@
 #Description: RTC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rtc_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/rtwdog/driver_rtwatchdog.cmake
+++ b/drivers/rtwdog/driver_rtwatchdog.cmake
@@ -1,5 +1,5 @@
 #Description: RTWDOG Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_rtwatchdog component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sai/driver_sai.cmake
+++ b/drivers/sai/driver_sai.cmake
@@ -1,5 +1,5 @@
 #Description: SAI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sai component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sai/driver_sai_edma.cmake
+++ b/drivers/sai/driver_sai_edma.cmake
@@ -1,5 +1,5 @@
 #Description: SAI EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sai_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sai/driver_sai_sdma.cmake
+++ b/drivers/sai/driver_sai_sdma.cmake
@@ -1,5 +1,5 @@
 #Description: SAI SDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sai_sdma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sctimer/driver_sctimer.cmake
+++ b/drivers/sctimer/driver_sctimer.cmake
@@ -1,5 +1,5 @@
 #Description: SCT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sctimer component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sdhc/driver_sdhc.cmake
+++ b/drivers/sdhc/driver_sdhc.cmake
@@ -1,5 +1,5 @@
 #Description: SDHC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sdhc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sdif/driver_sdif.cmake
+++ b/drivers/sdif/driver_sdif.cmake
@@ -1,5 +1,5 @@
 #Description: sdif Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sdif component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sdma/driver_sdma.cmake
+++ b/drivers/sdma/driver_sdma.cmake
@@ -1,5 +1,5 @@
 #Description: SDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sdma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sdramc/driver_sdramc.cmake
+++ b/drivers/sdramc/driver_sdramc.cmake
@@ -1,5 +1,5 @@
 #Description: SDRAMC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sdramc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sema4/driver_sema4.cmake
+++ b/drivers/sema4/driver_sema4.cmake
@@ -1,5 +1,5 @@
 #Description: SEMA4 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sema4 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sema42/driver_sema42.cmake
+++ b/drivers/sema42/driver_sema42.cmake
@@ -1,5 +1,5 @@
 #Description: SEMA42 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sema42 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/semc/driver_semc.cmake
+++ b/drivers/semc/driver_semc.cmake
@@ -1,5 +1,5 @@
 #Description: SEMC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_semc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sha/driver_sha.cmake
+++ b/drivers/sha/driver_sha.cmake
@@ -1,5 +1,5 @@
 #Description: SHA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sha component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sim/driver_sim.cmake
+++ b/drivers/sim/driver_sim.cmake
@@ -1,5 +1,5 @@
 #Description: SIM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sim component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/slcd/driver_slcd.cmake
+++ b/drivers/slcd/driver_slcd.cmake
@@ -1,5 +1,5 @@
 #Description: SLCD Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_slcd component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/smc/driver_smc.cmake
+++ b/drivers/smc/driver_smc.cmake
@@ -1,5 +1,5 @@
 #Description: SMC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_smc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/snvs_hp/driver_snvs_hp.cmake
+++ b/drivers/snvs_hp/driver_snvs_hp.cmake
@@ -1,5 +1,5 @@
 #Description: SNVS HP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_snvs_hp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/snvs_lp/driver_snvs_lp.cmake
+++ b/drivers/snvs_lp/driver_snvs_lp.cmake
@@ -1,5 +1,5 @@
 #Description: SNVS LP Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_snvs_lp component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/spi/driver_spi.cmake
+++ b/drivers/spi/driver_spi.cmake
@@ -1,5 +1,5 @@
 #Description: SPI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_spi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/spi/driver_spi_dma.cmake
+++ b/drivers/spi/driver_spi_dma.cmake
@@ -1,5 +1,5 @@
 #Description: SPI DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_spi_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/spi/driver_spi_freertos.cmake
+++ b/drivers/spi/driver_spi_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: SPI FREERTOS Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_spi_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/spifi/driver_spifi.cmake
+++ b/drivers/spifi/driver_spifi.cmake
@@ -1,5 +1,5 @@
 #Description: SPIFI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_spifi component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/spifi/driver_spifi_dma.cmake
+++ b/drivers/spifi/driver_spifi_dma.cmake
@@ -1,5 +1,5 @@
 #Description: SPIFI DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_spifi_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/spm/driver_spm.cmake
+++ b/drivers/spm/driver_spm.cmake
@@ -1,5 +1,5 @@
 #Description: SPM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_spm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/src/driver_src.cmake
+++ b/drivers/src/driver_src.cmake
@@ -1,5 +1,5 @@
 #Description: SRC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_src component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/swm/driver_swm.cmake
+++ b/drivers/swm/driver_swm.cmake
@@ -1,5 +1,5 @@
 #Description: SWM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_swm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/syscon/driver_syscon.cmake
+++ b/drivers/syscon/driver_syscon.cmake
@@ -1,5 +1,5 @@
 #Description: SYSCON Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_syscon component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sysctl/driver_sysctl.cmake
+++ b/drivers/sysctl/driver_sysctl.cmake
@@ -1,5 +1,5 @@
 #Description: SYSCTL Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sysctl component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/sysmpu/driver_sysmpu.cmake
+++ b/drivers/sysmpu/driver_sysmpu.cmake
@@ -1,5 +1,5 @@
 #Description: SYSMPU Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_sysmpu component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/tempmon/driver_tempmon.cmake
+++ b/drivers/tempmon/driver_tempmon.cmake
@@ -1,5 +1,5 @@
 #Description: TEMPMON Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_tempmon component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/tmu/driver_tmu.cmake
+++ b/drivers/tmu/driver_tmu.cmake
@@ -1,5 +1,5 @@
 #Description: TMU Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_tmu component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/tmu_1/driver_tmu_1.cmake
+++ b/drivers/tmu_1/driver_tmu_1.cmake
@@ -1,5 +1,5 @@
 #Description: TMU Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_tmu_1 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/tpm/driver_tpm.cmake
+++ b/drivers/tpm/driver_tpm.cmake
@@ -1,5 +1,5 @@
 #Description: TPM Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_tpm component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/trgmux/driver_trgmux.cmake
+++ b/drivers/trgmux/driver_trgmux.cmake
@@ -1,5 +1,5 @@
 #Description: TRGMUX Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_trgmux component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/trng/driver_trng.cmake
+++ b/drivers/trng/driver_trng.cmake
@@ -1,5 +1,5 @@
 #Description: TRNG Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_trng component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/tsi/driver_tsi_v4.cmake
+++ b/drivers/tsi/driver_tsi_v4.cmake
@@ -1,5 +1,5 @@
 #Description: TSI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_tsi_v4 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/tsi/driver_tsi_v5.cmake
+++ b/drivers/tsi/driver_tsi_v5.cmake
@@ -1,5 +1,5 @@
 #Description: TSI Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_tsi_v5 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/tstmr/driver_tstmr.cmake
+++ b/drivers/tstmr/driver_tstmr.cmake
@@ -1,5 +1,5 @@
 #Description: TSTMR Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_tstmr component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/uart/driver_uart.cmake
+++ b/drivers/uart/driver_uart.cmake
@@ -1,5 +1,5 @@
 #Description: UART Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_uart component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/uart/driver_uart_dma.cmake
+++ b/drivers/uart/driver_uart_dma.cmake
@@ -1,5 +1,5 @@
 #Description: UART DMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_uart_dma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/uart/driver_uart_edma.cmake
+++ b/drivers/uart/driver_uart_edma.cmake
@@ -1,5 +1,5 @@
 #Description: UART EDMA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_uart_edma component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/uart/driver_uart_freertos.cmake
+++ b/drivers/uart/driver_uart_freertos.cmake
@@ -1,5 +1,5 @@
 #Description: UART FREERTOS Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_uart_freertos component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/usdhc/driver_usdhc.cmake
+++ b/drivers/usdhc/driver_usdhc.cmake
@@ -1,5 +1,5 @@
 #Description: USDHC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_usdhc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/utick/driver_utick.cmake
+++ b/drivers/utick/driver_utick.cmake
@@ -1,5 +1,5 @@
 #Description: UTICK Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_utick component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/vref/driver_vref.cmake
+++ b/drivers/vref/driver_vref.cmake
@@ -1,5 +1,5 @@
 #Description: VREF Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_vref component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/wdog/driver_wdog.cmake
+++ b/drivers/wdog/driver_wdog.cmake
@@ -1,5 +1,5 @@
 #Description: WDOG Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_wdog component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/wdog01/driver_wdog01.cmake
+++ b/drivers/wdog01/driver_wdog01.cmake
@@ -1,5 +1,5 @@
 #Description: wdog01 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_wdog01 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/wdog32/driver_wdog32.cmake
+++ b/drivers/wdog32/driver_wdog32.cmake
@@ -1,5 +1,5 @@
 #Description: WDOG32 Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_wdog32 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/wdog8/driver_wdog8.cmake
+++ b/drivers/wdog8/driver_wdog8.cmake
@@ -1,5 +1,5 @@
 #Description: WDOG Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_wdog8 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/wkt/driver_wkt.cmake
+++ b/drivers/wkt/driver_wkt.cmake
@@ -1,5 +1,5 @@
 #Description: WKT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_wkt component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/wwdt/driver_wwdt.cmake
+++ b/drivers/wwdt/driver_wwdt.cmake
@@ -1,5 +1,5 @@
 #Description: WWDT Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_wwdt component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/xbar/driver_xbar.cmake
+++ b/drivers/xbar/driver_xbar.cmake
@@ -1,5 +1,5 @@
 #Description: XBAR Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xbar component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/xbara/driver_xbara.cmake
+++ b/drivers/xbara/driver_xbara.cmake
@@ -1,5 +1,5 @@
 #Description: XBARA Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xbara component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/xbarb/driver_xbarb.cmake
+++ b/drivers/xbarb/driver_xbarb.cmake
@@ -1,5 +1,5 @@
 #Description: XBARB Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xbarb component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/drivers/xrdc/driver_xrdc.cmake
+++ b/drivers/xrdc/driver_xrdc.cmake
@@ -1,5 +1,5 @@
 #Description: XRDC Driver; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("driver_xrdc component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/middleware/issdk/middleware_issdk_algorithms_pedometer_common.cmake
+++ b/middleware/issdk/middleware_issdk_algorithms_pedometer_common.cmake
@@ -1,5 +1,5 @@
 #Description: Middleware issdk algorithms pedometer common; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("middleware_issdk_algorithms_pedometer_common component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/middleware/issdk/middleware_issdk_algorithms_pedometer_lib_cm4.cmake
+++ b/middleware/issdk/middleware_issdk_algorithms_pedometer_lib_cm4.cmake
@@ -1,5 +1,5 @@
 #Description: Middleware issdk algorithms pedometer lib_cm4; user_visible: False
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("middleware_issdk_algorithms_pedometer_lib_cm4 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/middleware/issdk/middleware_issdk_sensor_allregdefs.cmake
+++ b/middleware/issdk/middleware_issdk_sensor_allregdefs.cmake
@@ -1,5 +1,5 @@
 #Description: Middleware issdk sensor allregdefs; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("middleware_issdk_sensor_allregdefs component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/middleware/mmcau/middleware_mmcau_cm0p.cmake
+++ b/middleware/mmcau/middleware_mmcau_cm0p.cmake
@@ -1,5 +1,5 @@
 #Description: Kinetis MMCAU security function library for Arm Cortex-M0+; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("middleware_mmcau_cm0p component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/middleware/mmcau/middleware_mmcau_cm4_cm7.cmake
+++ b/middleware/mmcau/middleware_mmcau_cm4_cm7.cmake
@@ -1,5 +1,5 @@
 #Description: Kinetis MMCAU security function library for Arm Cortex-M4 and Cortex-M7; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("middleware_mmcau_cm4_cm7 component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/middleware/mmcau/middleware_mmcau_common_files.cmake
+++ b/middleware/mmcau/middleware_mmcau_common_files.cmake
@@ -1,5 +1,5 @@
 #Description: Kinetis MMCAU common source files; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("middleware_mmcau_common_files component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/middleware/usb/middleware_usb_common_header.cmake
+++ b/middleware/usb/middleware_usb_common_header.cmake
@@ -1,5 +1,5 @@
 #Description: USB Common Header; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("middleware_usb_common_header component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/middleware/usb/middleware_usb_device_common_header.cmake
+++ b/middleware/usb/middleware_usb_device_common_header.cmake
@@ -1,5 +1,5 @@
 #Description: USB Device Common Header; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("middleware_usb_device_common_header component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/middleware_baremetal.cmake
+++ b/middleware_baremetal.cmake
@@ -1,5 +1,5 @@
 #Description: middleware_baremetal; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("middleware_baremetal component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/utilities/assert/utility_assert.cmake
+++ b/utilities/assert/utility_assert.cmake
@@ -1,5 +1,5 @@
 #Description: Utility assert; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_assert component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/utilities/assert/utility_assert_lite.cmake
+++ b/utilities/assert/utility_assert_lite.cmake
@@ -1,5 +1,5 @@
 #Description: Utility assert_lite; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_assert_lite component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/utilities/debug_console/utility_debug_console.cmake
+++ b/utilities/debug_console/utility_debug_console.cmake
@@ -1,5 +1,5 @@
 #Description: Utility debug_console; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_debug_console component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/utilities/debug_console_lite/utility_debug_console_lite.cmake
+++ b/utilities/debug_console_lite/utility_debug_console_lite.cmake
@@ -1,5 +1,5 @@
 #Description: Utility debug_console_lite; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_debug_console_lite component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/utilities/misc_utilities/utilities_misc_utilities.cmake
+++ b/utilities/misc_utilities/utilities_misc_utilities.cmake
@@ -1,5 +1,5 @@
 #Description: utilities_misc_utilities; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utilities_misc_utilities component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE

--- a/utilities/misc_utilities/utility_incbin.cmake
+++ b/utilities/misc_utilities/utility_incbin.cmake
@@ -1,5 +1,5 @@
 #Description: utility incbin; user_visible: True
-include_guard(GLOBAL)
+include_guard(DIRECTORY)
 message("utility_incbin component is included.")
 
 target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE


### PR DESCRIPTION
**Prerequisites**
- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

This changes the include guards in the cmake files from global to directory. Reason for this is lets say you want to create multiple executables in two different CMakeLists.txt files and need to therefore use the mcux utilitiy functions twice in order to create those executables. If the guards are global, on the second pass, those calls to `include()` will not run as they will be blocked. With the change to directory, the includes will be blocked on the stack call for a given executable (so multiple calls to an include will block), but the moment it pops up from that executable it is free to be called again for another.

**Type of change** (please delete options that are not relevant):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

* Test configuration (please complete the following information):
   - Hardware setting:
   - Toolchain:
   - Test Tool preparation:
   - Any other dependencies:
* Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 
    - [ ] Build Test
    - [ ] Run Test

