### PR TITLE
Fixes #100. Fix CAN_Type* in FLEXCAN2 ISR

### DIFF
--- a/drivers/flexcan/fsl_flexcan.c
+++ b/drivers/flexcan/fsl_flexcan.c
@@ -4643,7 +4643,7 @@ void CAN_FD2_DriverIRQHandler(void)
 {
     assert(NULL != s_flexcanHandle[2]);
 
-    s_flexcanIsr(FLEXCAN1, s_flexcanHandle[2]);
+    s_flexcanIsr(FLEXCAN2, s_flexcanHandle[2]);
     SDK_ISR_EXIT_BARRIER;
 }
 #endif


### PR DESCRIPTION
The FLEXCAN driver uses an apparently wrong CAN_Type*/base address as argument to the `s_flexcanIsr` handler for interrupts on FLEXCAN2. This change makes the `CAN_FD2_DriverIRQHandler` use the correct base address.

**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
Use correct base address pointer in `CAN_FD2_DriverIRQHandler` of the flexcan driver.
Fixes #100

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: MIMX8ML8
  - Toolchain: arm-none-eabi-gcc 12.2.0
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [x] Build Test
  - [x] Run Test
  Try to send or receive any CAN frame on FLEXCAN2 using the transactional API