### PR TITLE
Remove assert from linker files imx7ulp

### DIFF
--- a/devices/MCIMX7U3/gcc/MCIMX7U3xxxxx_cm4_flash.ld
+++ b/devices/MCIMX7U3/gcc/MCIMX7U3xxxxx_cm4_flash.ld
@@ -183,10 +183,6 @@ SECTIONS
     __data_end__ = .;        /* define a global symbol at data end */
   } > m_data
 
-  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
-  text_end = ORIGIN(m_text) + LENGTH(m_text);
-  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
-
   /* Uninitialized data section */
   .bss :
   {
@@ -234,4 +230,3 @@ SECTIONS
 
   ASSERT(__StackLimit >= __HeapLimit, "region m_data_2 overflowed with stack and heap")
 }
-

--- a/devices/MCIMX7U3/gcc/MCIMX7U3xxxxx_cm4_ram.ld
+++ b/devices/MCIMX7U3/gcc/MCIMX7U3xxxxx_cm4_ram.ld
@@ -177,10 +177,6 @@ SECTIONS
     __data_end__ = .;        /* define a global symbol at data end */
   } > m_data
 
-  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
-  text_end = ORIGIN(m_text) + LENGTH(m_text);
-  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
-
   /* Uninitialized data section */
   .bss :
   {
@@ -228,4 +224,3 @@ SECTIONS
 
   ASSERT(__StackLimit >= __HeapLimit, "region m_data overflowed with stack and heap")
 }
-

--- a/devices/MCIMX7U5/gcc/MCIMX7U5xxxxx_cm4_flash.ld
+++ b/devices/MCIMX7U5/gcc/MCIMX7U5xxxxx_cm4_flash.ld
@@ -184,10 +184,6 @@ SECTIONS
     __data_end__ = .;        /* define a global symbol at data end */
   } > m_data
 
-  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
-  text_end = ORIGIN(m_text) + LENGTH(m_text);
-  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
-
   /* Uninitialized data section */
   .bss :
   {
@@ -235,4 +231,3 @@ SECTIONS
 
   ASSERT(__StackLimit >= __HeapLimit, "region m_data_2 overflowed with stack and heap")
 }
-

--- a/devices/MCIMX7U5/gcc/MCIMX7U5xxxxx_cm4_ram.ld
+++ b/devices/MCIMX7U5/gcc/MCIMX7U5xxxxx_cm4_ram.ld
@@ -178,10 +178,6 @@ SECTIONS
     __data_end__ = .;        /* define a global symbol at data end */
   } > m_data
 
-  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
-  text_end = ORIGIN(m_text) + LENGTH(m_text);
-  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
-
   /* Uninitialized data section */
   .bss :
   {
@@ -229,4 +225,3 @@ SECTIONS
 
   ASSERT(__StackLimit >= __HeapLimit, "region m_data overflowed with stack and heap")
 }
-


### PR DESCRIPTION
Signed-off-by: Cervenka Dusan <cervenka@acrios.com>

**Prerequisites**

- [X] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [X] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->
It looks like linker files (maybe also for different targets) contains ASSERT which was copied and paste without checking and evaluating its reason. As data section compared with assert are from different memory sections and between them exists another sections which are not checked and it is throwing error even memory sections are not completely used i think this assert should be removed.

Please check also other linker files if you agree with me

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: imx7ulp
  - Toolchain: gcc 11.3 (and gcc10.3)
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [X] Build Test
  - [X] Run Test
