### PR TITLE
drivers: flexio: fixes SPI Master SHIFTBUF Overrun

### DIFF
--- a/drivers/flexio/fsl_flexio_spi.c
+++ b/drivers/flexio/fsl_flexio_spi.c
@@ -1307,8 +1307,14 @@ void FLEXIO_SPI_MasterTransferHandleIRQ(void *spiType, void *spiHandle)
     base   = (FLEXIO_SPI_Type *)spiType;
     status = FLEXIO_SPI_GetStatusFlags(base);
 
+    /* Receive interrupt. */
+    if ((status & (uint32_t)kFLEXIO_SPI_RxBufferFullFlag) == 0)
+    {
+        return;
+    }
+
     /* Handle rx. */
-    if (((status & (uint32_t)kFLEXIO_SPI_RxBufferFullFlag) != 0U) && (handle->rxRemainingBytes != 0U))
+    if (handle->rxRemainingBytes != 0U)
     {
         FLEXIO_SPI_TransferReceiveTransaction(base, handle);
     }


### PR DESCRIPTION
When implementing multiple FLEXIO SPIs, the parent interrupt handler calls all child interrupt handlers in turn, for example FLEXIO_SPI_MasterTransferHandleIRQ().
The problem appears when the interrupt is generated by one interface, and in another interface the send buffer is empty
(kFLEXIO_SPI_TxBufferEmptyFlag is set), and there is no data in the receive buffer yet (kFLEXIO_SPI_RxBufferFullFlag is not set), then without waiting for data in the receive buffer, the handler will send new data, which will result in to data loss (SHIFTBUF Overrun). Since in SPI MASTER mode an interrupt is generated only when the receive buffer is full, the child interrupt handler should only be executed when the receive buffer is full.

Signed-off-by: Mikhail Siomin <mikhail.siomin@nxp.com>

**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting:
  - Toolchain:
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [ ] Build Test
  - [ ] Run Test
