### PR TITLE
mcux: mcux-sdk: driver: flexcan: propagate timestamp on RxOverflow

### DIFF
--- a/drivers/flexcan/fsl_flexcan.c
+++ b/drivers/flexcan/fsl_flexcan.c
@@ -4253,22 +4253,28 @@ static status_t FLEXCAN_SubHandlerForDataTransfered(CAN_Type *base, flexcan_hand
                     if (0U != (base->MCR & CAN_MCR_FDEN_MASK))
                     {
                         status = FLEXCAN_ReadFDRxMb(base, (uint8_t)result, handle->mbFDFrameBuf[result]);
-                        if (kStatus_Success == status)
+                        if (kStatus_Success == status || kStatus_FLEXCAN_RxOverflow == status)
                         {
                             /* Align the current index of RX MB timestamp to the timestamp array by handle. */
                             handle->timestamp[result] = handle->mbFDFrameBuf[result]->timestamp;
-                            status                    = kStatus_FLEXCAN_RxIdle;
+                            if (kStatus_Success == status)
+                            {
+                                status = kStatus_FLEXCAN_RxIdle;
+                            }
                         }
                     }
                     else
 #endif
                     {
                         status = FLEXCAN_ReadRxMb(base, (uint8_t)result, handle->mbFrameBuf[result]);
-                        if (kStatus_Success == status)
+                        if (kStatus_Success == status || kStatus_FLEXCAN_RxOverflow == status)
                         {
                             /* Align the current index of RX MB timestamp to the timestamp array by handle. */
                             handle->timestamp[result] = handle->mbFrameBuf[result]->timestamp;
-                            status                    = kStatus_FLEXCAN_RxIdle;
+                            if (kStatus_Success == status)
+                            {
+                                status = kStatus_FLEXCAN_RxIdle;
+                            }
                         }
                     }
 #if (defined(FSL_FEATURE_FLEXCAN_HAS_FLEXIBLE_DATA_RATE) && FSL_FEATURE_FLEXCAN_HAS_FLEXIBLE_DATA_RATE)


### PR DESCRIPTION
**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
Propagate timestamp on kStatus_FLEXCAN_RxOverflow status when using the FlexCAN transactional APIs. Originally submitted to the NXP HAL in Zephyr RTOS: https://github.com/zephyrproject-rtos/hal_nxp/pull/217

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: twr_ke18f, mimxrt1024_evk, frdm_k64f
  - Toolchain: Zephyr SDK 0.15.2
  - Test Tool preparation: N/A
  - Any other dependencies: Zephyr RTOS
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [x] Build Test
  - [x] Run Test

