### PR TITLE
Enable MU for HiFi4 DSP from i.MX8M Plus

### DIFF
--- a/devices/MIMX8ML8/all_lib_device_MIMX8ML8_dsp.cmake
+++ b/devices/MIMX8ML8/all_lib_device_MIMX8ML8_dsp.cmake
@@ -3,6 +3,7 @@ list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_LIST_DIR}/../../components/uart
     ${CMAKE_CURRENT_LIST_DIR}/../../drivers/common
     ${CMAKE_CURRENT_LIST_DIR}/../../drivers/iuart
+    ${CMAKE_CURRENT_LIST_DIR}/../../drivers/mu
     ${CMAKE_CURRENT_LIST_DIR}/drivers
 )
 
@@ -10,3 +11,4 @@ list(APPEND CMAKE_MODULE_PATH
 # Copy the cmake components into projects
 #    include(driver_iuart)
 #    include(driver_common)
+#    include(driver_mu)


### PR DESCRIPTION
**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [ ] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
Add MU support for HiFi4 DSP from i.MX8 M Plus target.
This is used for IPC.
Having this enabled we can run the openamp_rsc_table sample from Zephyr:  https://github.com/zephyrproject-rtos/zephyr/tree/main/samples/subsys/ipc/openamp_rsc_table

**Type of change**
Enable MU for DSP

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: DSP from i.MX8MP
  - Toolchain: gcc
 
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [x] Build Test
   Build Zephyr sample `openamp_rsc_table` for nxp_adsp_imx8m board
  - [x] Run Test
  Run Zephyr sample `openamp_rsc_table `and the output will be displayed on console.
