### PR TITLE
devices: Add MIMX9352 support

### DIFF
--- a/devices/MIMX9352/MIMX9352_ca55_features.h
+++ b/devices/MIMX9352/MIMX9352_ca55_features.h
@@ -1,0 +1,554 @@
+/*
+** ###################################################################
+**     Version:             rev. 1.0, 2021-11-16
+**     Build:               b221019
+**
+**     Abstract:
+**         Chip specific module features.
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2022 NXP
+**     All rights reserved.
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+**     Revisions:
+**     - rev. 1.0 (2021-11-16)
+**         Initial version.
+**
+** ###################################################################
+*/
+
+#ifndef _MIMX9352_ca55_FEATURES_H_
+#define _MIMX9352_ca55_FEATURES_H_
+
+/* SOC module features */
+
+/* @brief AXBS availability on the SoC. */
+#define FSL_FEATURE_SOC_AXBS_COUNT (1)
+/* @brief DDR availability on the SoC. */
+#define FSL_FEATURE_SOC_DDR_COUNT (1)
+/* @brief DMA4 availability on the SoC. */
+#define FSL_FEATURE_SOC_DMA4_COUNT (1)
+/* @brief EDMA availability on the SoC. */
+#define FSL_FEATURE_SOC_EDMA_COUNT (1)
+/* @brief ENET availability on the SoC. */
+#define FSL_FEATURE_SOC_ENET_COUNT (1)
+/* @brief ENET_QOS availability on the SoC. */
+#define FSL_FEATURE_SOC_ENET_QOS_COUNT (1)
+/* @brief FLEXCAN availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXCAN_COUNT (2)
+/* @brief FLEXIO availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXIO_COUNT (2)
+/* @brief FLEXSPI availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXSPI_COUNT (1)
+/* @brief GPC availability on the SoC. */
+#define FSL_FEATURE_SOC_GPC_COUNT (4)
+/* @brief I3C availability on the SoC. */
+#define FSL_FEATURE_SOC_I3C_COUNT (2)
+/* @brief I2S availability on the SoC. */
+#define FSL_FEATURE_SOC_I2S_COUNT (3)
+/* @brief ISI availability on the SoC. */
+#define FSL_FEATURE_SOC_ISI_COUNT (1)
+/* @brief LCDIF availability on the SoC. */
+#define FSL_FEATURE_SOC_LCDIF_COUNT (1)
+/* @brief LPI2C availability on the SoC. */
+#define FSL_FEATURE_SOC_LPI2C_COUNT (8)
+/* @brief LPIT availability on the SoC. */
+#define FSL_FEATURE_SOC_LPIT_COUNT (2)
+/* @brief LPSPI availability on the SoC. */
+#define FSL_FEATURE_SOC_LPSPI_COUNT (8)
+/* @brief LPTMR availability on the SoC. */
+#define FSL_FEATURE_SOC_LPTMR_COUNT (2)
+/* @brief LPUART availability on the SoC. */
+#define FSL_FEATURE_SOC_LPUART_COUNT (8)
+/* @brief MCM availability on the SoC. */
+#define FSL_FEATURE_SOC_MCM_COUNT (1)
+/* @brief MIPI_DSI availability on the SoC. */
+#define FSL_FEATURE_SOC_MIPI_DSI_COUNT (1)
+/* @brief NPU availability on the SoC. */
+#define FSL_FEATURE_SOC_NPU_COUNT (1)
+/* @brief OCOTP availability on the SoC. */
+#define FSL_FEATURE_SOC_OCOTP_COUNT (1)
+/* @brief OTFAD availability on the SoC. */
+#define FSL_FEATURE_SOC_OTFAD_COUNT (1)
+/* @brief PDM availability on the SoC. */
+#define FSL_FEATURE_SOC_PDM_COUNT (1)
+/* @brief PXP availability on the SoC. */
+#define FSL_FEATURE_SOC_PXP_COUNT (1)
+/* @brief RGPIO availability on the SoC. */
+#define FSL_FEATURE_SOC_RGPIO_COUNT (4)
+/* @brief ROMC availability on the SoC. */
+#define FSL_FEATURE_SOC_ROMC_COUNT (2)
+/* @brief SEMA42 availability on the SoC. */
+#define FSL_FEATURE_SOC_SEMA42_COUNT (2)
+/* @brief SFA availability on the SoC. */
+#define FSL_FEATURE_SOC_SFA_COUNT (1)
+/* @brief SPDIF availability on the SoC. */
+#define FSL_FEATURE_SOC_SPDIF_COUNT (1)
+/* @brief SRC availability on the SoC. */
+#define FSL_FEATURE_SOC_SRC_COUNT (13)
+/* @brief TPM availability on the SoC. */
+#define FSL_FEATURE_SOC_TPM_COUNT (6)
+/* @brief TRGMUX availability on the SoC. */
+#define FSL_FEATURE_SOC_TRGMUX_COUNT (1)
+/* @brief TSTMR availability on the SoC. */
+#define FSL_FEATURE_SOC_TSTMR_COUNT (2)
+/* @brief USB availability on the SoC. */
+#define FSL_FEATURE_SOC_USB_COUNT (2)
+/* @brief USBNC availability on the SoC. */
+#define FSL_FEATURE_SOC_USBNC_COUNT (2)
+/* @brief USDHC availability on the SoC. */
+#define FSL_FEATURE_SOC_USDHC_COUNT (3)
+/* @brief WDOG availability on the SoC. */
+#define FSL_FEATURE_SOC_WDOG_COUNT (5)
+/* @brief XCACHE availability on the SoC. */
+#define FSL_FEATURE_SOC_XCACHE_COUNT (2)
+
+/* FLEXCAN module features */
+
+/* @brief Message buffer size */
+#define FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(x) (96)
+/* @brief Has doze mode support (register bit field MCR[DOZE]). */
+#define FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT (1)
+/* @brief Insatnce has doze mode support (register bit field MCR[DOZE]). */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_DOZE_MODE_SUPPORTn(x) (1)
+/* @brief Has a glitch filter on the receive pin (register bit field MCR[WAKSRC]). */
+#define FSL_FEATURE_FLEXCAN_HAS_GLITCH_FILTER (1)
+/* @brief Has extended interrupt mask and flag register (register IMASK2, IFLAG2). */
+#define FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER (1)
+/* @brief Instance has extended bit timing register (register CBT). */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_EXTENDED_TIMING_REGISTERn(x) (1)
+/* @brief Has a receive FIFO DMA feature (register bit field MCR[DMA]). */
+#define FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA (1)
+/* @brief Instance has a receive FIFO DMA feature (register bit field MCR[DMA]). */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_RX_FIFO_DMAn(x) (1)
+/* @brief Remove CAN Engine Clock Source Selection from unsupported part. */
+#define FSL_FEATURE_FLEXCAN_SUPPORT_ENGINE_CLK_SEL_REMOVE (0)
+/* @brief Instance remove CAN Engine Clock Source Selection from unsupported part. */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_SUPPORT_ENGINE_CLK_SEL_REMOVEn(x) (0)
+/* @brief Is affected by errata with ID 5641 (Module does not transmit a message that is enabled to be transmitted at a specific moment during the arbitration process). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_5641 (0)
+/* @brief Is affected by errata with ID 5829 (FlexCAN: FlexCAN does not transmit a message that is enabled to be transmitted in a specific moment during the arbitration process). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_5829 (0)
+/* @brief Is affected by errata with ID 6032 (FlexCAN: A frame with wrong ID or payload is transmitted into the CAN bus when the Message Buffer under transmission is either aborted or deactivated while the CAN bus is in the Bus Idle state). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_6032 (0)
+/* @brief Is affected by errata with ID 9595 (FlexCAN: Corrupt frame possible if the Freeze Mode or the Low-Power Mode are entered during a Bus-Off state). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_9595 (0)
+/* @brief Has CAN with Flexible Data rate (CAN FD) protocol. */
+#define FSL_FEATURE_FLEXCAN_HAS_FLEXIBLE_DATA_RATE (1)
+/* @brief CAN instance support Flexible Data rate (CAN FD) protocol. */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_FLEXIBLE_DATA_RATEn(x) (1)
+/* @brief Has memory error control (register MECR). */
+#define FSL_FEATURE_FLEXCAN_HAS_MEMORY_ERROR_CONTROL (1)
+/* @brief Init memory base 1 */
+#define FSL_FEATURE_FLEXCAN_INIT_MEMORY_BASE_1 (0x80)
+/* @brief Init memory size 1 */
+#define FSL_FEATURE_FLEXCAN_INIT_MEMORY_SIZE_1 (0xA60)
+/* @brief Init memory base 2 */
+#define FSL_FEATURE_FLEXCAN_INIT_MEMORY_BASE_2 (0xC20)
+/* @brief Init memory size 2 */
+#define FSL_FEATURE_FLEXCAN_INIT_MEMORY_SIZE_2 (0x25E0)
+/* @brief Has enhanced bit timing register (register EPRS, ENCBT, EDCBT and ETDC). */
+#define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG (1)
+/* @brief Has Pretended Networking mode support. */
+#define FSL_FEATURE_FLEXCAN_HAS_PN_MODE (0)
+/* @brief Has Enhanced Rx FIFO. */
+#define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_RX_FIFO (1)
+/* @brief Enhanced Rx FIFO size (Indicates how many CAN FD messages can be stored). */
+#define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_RX_FIFO_SIZE (20)
+/* @brief The number of enhanced Rx FIFO filter element registers. */
+#define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_RX_FIFO_FILTER_MAX_NUMBER (128)
+/* @brief Does not support Supervisor Mode (bitfield MCR[SUPV]. */
+#define FSL_FEATURE_FLEXCAN_HAS_NO_SUPV_SUPPORT (0)
+
+/* EDMA module features */
+
+/* @brief Number of DMA channels (related to number of registers TCD, DCHPRI, bit fields ERQ[ERQn], EEI[EEIn], INT[INTn], ERR[ERRn], HRS[HRSn] and bit field widths ES[ERRCHN], CEEI[CEEI], SEEI[SEEI], CERQ[CERQ], SERQ[SERQ], CDNE[CDNE], SSRT[SSRT], CERR[CERR], CINT[CINT], TCDn_CITER_ELINKYES[LINKCH], TCDn_CSR[MAJORLINKCH], TCDn_BITER_ELINKYES[LINKCH]). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_MODULE_CHANNEL (31)
+/* @brief Total number of DMA channels on all modules. */
+#define FSL_FEATURE_EDMA_DMAMUX_CHANNELS (31)
+/* @brief Number of DMA channel groups (register bit fields CR[ERGA], CR[GRPnPRI], ES[GPE], DCHPRIn[GRPPRI]). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_CHANNEL_GROUP_COUNT (1)
+/* @brief Has DMA_Error interrupt vector. */
+#define FSL_FEATURE_EDMA_HAS_ERROR_IRQ (1)
+/* @brief Number of DMA channels with asynchronous request capability (register EARS). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_ASYNCHRO_REQUEST_CHANNEL_COUNT (32)
+/* @brief If channel clock controlled independently */
+#define FSL_FEATURE_EDMA_CHANNEL_HAS_OWN_CLOCK_GATE (1)
+/* @brief Number of channel for each EDMA instance, (only defined for soc with different channel numbers for difference instance) */
+#define FSL_FEATURE_EDMA_INSTANCE_CHANNELn(x) (31)
+/* @brief Has no register bit fields MP_CSR[EBW]. */
+#define FSL_FEATURE_EDMA_HAS_NO_MP_CSR_EBW (1)
+/* @brief If dma has channel mux */
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_MUX (0)
+/* @brief If dma has common clock gate */
+#define FSL_FEATURE_EDMA_HAS_COMMON_CLOCK_GATE (0)
+/* @brief If dma channel IRQ support parameter */
+#define FSL_FEATURE_EDMA_MODULE_CHANNEL_IRQ_ENTRY_SUPPORT_PARAMETER (0)
+/* @brief If 8 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_8_BYTES_TRANSFER (1)
+/* @brief If 16 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_16_BYTES_TRANSFER (1)
+/* @brief If 64 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_64_BYTES_TRANSFER (1)
+/* @brief Has no register bit fields CH_SBR[ATTR]. */
+#define FSL_FEATURE_EDMA_HAS_NO_CH_SBR_ATTR (1)
+
+/* DMA_TCD module features */
+
+/* @brief Has no supervisor access bit (CR). */
+#define FSL_FEATURE_DMA_TCD_HAS_NO_CR_SUP (1)
+/* @brief Has no oscillator enable bit (CR). */
+#define FSL_FEATURE_DMA_TCD_HAS_NO_CR_OSCE (1)
+
+/* ENET module features */
+
+/* @brief Support Interrupt Coalesce */
+#define FSL_FEATURE_ENET_HAS_INTERRUPT_COALESCE (1)
+/* @brief Queue Size. */
+#define FSL_FEATURE_ENET_QUEUE (3)
+/* @brief Has AVB Support. */
+#define FSL_FEATURE_ENET_HAS_AVB (1)
+/* @brief Has Timer Pulse Width control. */
+#define FSL_FEATURE_ENET_HAS_TIMER_PWCONTROL (0)
+/* @brief Has Extend MDIO Support. */
+#define FSL_FEATURE_ENET_HAS_EXTEND_MDIO (1)
+/* @brief Has Additional 1588 Timer Channel Interrupt. */
+#define FSL_FEATURE_ENET_HAS_ADD_1588_TIMER_CHN_INT (0)
+/* @brief Support Interrupt Coalesce for each instance */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_INTERRUPT_COALESCEn(x) (1)
+/* @brief Queue Size for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_QUEUEn(x) (3)
+/* @brief Has AVB Support for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_AVBn(x) (1)
+/* @brief Has Timer Pulse Width control for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_TIMER_PWCONTROLn(x) (0)
+/* @brief Has Extend MDIO Support for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_EXTEND_MDIOn(x) (1)
+/* @brief Has Additional 1588 Timer Channel Interrupt for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_ADD_1588_TIMER_CHN_INTn(x) (0)
+/* @brief Has threshold for the number of frames in the receive FIFO (register bit field RSEM[STAT_SECTION_EMPTY]). */
+#define FSL_FEATURE_ENET_HAS_RECEIVE_STATUS_THRESHOLD (1)
+/* @brief Has trasfer clock delay (register bit field ECR[TXC_DLY]). */
+#define FSL_FEATURE_ENET_HAS_RGMII_TXC_DELAY (1)
+/* @brief Has receive clock delay (register bit field ECR[RXC_DLY]). */
+#define FSL_FEATURE_ENET_HAS_RGMII_RXC_DELAY (1)
+/* @brief PTP Timestamp CAPTURE bit always returns 0 when the capture is not over. */
+#define FSL_FEATURE_ENET_TIMESTAMP_CAPTURE_BIT_INVALID (0)
+/* @brief ENET Has Extra Clock Gate.(RW610). */
+#define FSL_FEATURE_ENET_HAS_EXTRA_CLOCK_GATE (0)
+
+/* ENET_QOS module features */
+
+/* No feature definitions */
+
+/* FLEXSPI module features */
+
+/* @brief FlexSPI AHB buffer count */
+#define FSL_FEATURE_FLEXSPI_AHB_BUFFER_COUNTn(x) (8)
+/* @brief FlexSPI has no MCR0 ARDFEN bit */
+#define FSL_FEATURE_FLEXSPI_HAS_NO_MCR0_ARDFEN (0)
+/* @brief FlexSPI has no MCR0 ATDFEN bit */
+#define FSL_FEATURE_FLEXSPI_HAS_NO_MCR0_ATDFEN (0)
+
+/* RGPIO module features */
+
+/* @brief Has GPIO attribute checker register  (GACR). */
+#define FSL_FEATURE_RGPIO_HAS_ATTRIBUTE_CHECKER (0)
+/* @brief There is ICR registers */
+#define FSL_FEATURE_RGPIO_HAS_IRQ_CONFIG (1)
+/* @brief There is PIDR register */
+#define FSL_FEATURE_RGPIO_HAS_PORT_INPUT_DISABLE (1)
+
+/* I3C module features */
+
+/* @brief Has TERM bitfile in MERRWARN register. */
+#define FSL_FEATURE_I3C_HAS_NO_MERRWARN_TERM (0)
+/* @brief SOC has no reset driver. */
+#define FSL_FEATURE_I3C_HAS_NO_RESET (1)
+/* @brief Use fixed BAMATCH count, do not provide editable BAMATCH. */
+#define FSL_FEATURE_I3C_HAS_NO_SCONFIG_BAMATCH (0)
+/* @brief Register SCONFIG do not have IDRAND bitfield. */
+#define FSL_FEATURE_I3C_HAS_NO_SCONFIG_IDRAND (1)
+/* @brief Register SCONFIG has HDROK bitfield. */
+#define FSL_FEATURE_I3C_HAS_HDROK (1)
+
+/* XCACHE module features */
+
+/* @brief Cache Line size in byte. */
+#define FSL_FEATURE_XCACHE_LINESIZE_BYTE (16)
+/* @brief Cache doesn't support write buffer. */
+#define FSL_FEATURE_XCACHE_HAS_NO_WRITE_BUF (1)
+
+/* LPI2C module features */
+
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPI2C_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPI2C_FIFO_SIZEn(x) (8)
+
+/* LPIT module features */
+
+/* @brief Number of channels (related to number of registers LDVALn, CVALn, TCTRLn, TFLGn). */
+#define FSL_FEATURE_LPIT_TIMER_COUNT (4)
+/* @brief Has lifetime timer (related to existence of registers LTMR64L and LTMR64H). */
+#define FSL_FEATURE_LPIT_HAS_LIFETIME_TIMER (0)
+/* @brief Has shared interrupt handler (has not individual interrupt handler for each channel). */
+#define FSL_FEATURE_LPIT_HAS_SHARED_IRQ_HANDLER (1)
+
+/* LPSPI module features */
+
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPSPI_FIFO_SIZEn(x) (8)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPSPI_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Has CCR1 (related to existence of registers CCR1). */
+#define FSL_FEATURE_LPSPI_HAS_CCR1 (1)
+
+/* LPTMR module features */
+
+/* @brief Has shared interrupt handler with another LPTMR module. */
+#define FSL_FEATURE_LPTMR_HAS_SHARED_IRQ_HANDLER (0)
+/* @brief Whether LPTMR counter is 32 bits width. */
+#define FSL_FEATURE_LPTMR_CNR_WIDTH_IS_32B (1)
+/* @brief Has timer DMA request enable (register bit CSR[TDRE]). */
+#define FSL_FEATURE_LPTMR_HAS_CSR_TDRE (1)
+/* @brief Do not has prescaler clock source 1. */
+#define FSL_FEATURE_LPTMR_HAS_NO_PRESCALER_CLOCK_SOURCE_1_SUPPORT (0)
+/* @brief Do not has prescaler clock source 3. */
+#define FSL_FEATURE_LPTMR_HAS_NO_PRESCALER_CLOCK_SOURCE_3_SUPPORT (0)
+
+/* LPUART module features */
+
+/* @brief Has receive FIFO overflow detection (bit field CFIFO[RXOFE]). */
+#define FSL_FEATURE_LPUART_HAS_IRQ_EXTENDED_FUNCTIONS (0)
+/* @brief Has low power features (can be enabled in wait mode via register bit C1[DOZEEN] or CTRL[DOZEEN] if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_LOW_POWER_UART_SUPPORT (1)
+/* @brief Has extended data register ED (or extra flags in the DATA register if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_EXTENDED_DATA_REGISTER_FLAGS (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPUART_HAS_FIFO (1)
+/* @brief Has 32-bit register MODIR */
+#define FSL_FEATURE_LPUART_HAS_MODIR (1)
+/* @brief Hardware flow control (RTS, CTS) is supported. */
+#define FSL_FEATURE_LPUART_HAS_MODEM_SUPPORT (1)
+/* @brief Infrared (modulation) is supported. */
+#define FSL_FEATURE_LPUART_HAS_IR_SUPPORT (1)
+/* @brief 2 bits long stop bit is available. */
+#define FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT (1)
+/* @brief If 10-bit mode is supported. */
+#define FSL_FEATURE_LPUART_HAS_10BIT_DATA_SUPPORT (1)
+/* @brief If 7-bit mode is supported. */
+#define FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT (1)
+/* @brief Baud rate fine adjustment is available. */
+#define FSL_FEATURE_LPUART_HAS_BAUD_RATE_FINE_ADJUST_SUPPORT (0)
+/* @brief Baud rate oversampling is available (has bit fields C4[OSR], C5[BOTHEDGE], C5[RESYNCDIS] or BAUD[OSR], BAUD[BOTHEDGE], BAUD[RESYNCDIS] if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_BAUD_RATE_OVER_SAMPLING_SUPPORT (1)
+/* @brief Baud rate oversampling is available. */
+#define FSL_FEATURE_LPUART_HAS_RX_RESYNC_SUPPORT (1)
+/* @brief Baud rate oversampling is available. */
+#define FSL_FEATURE_LPUART_HAS_BOTH_EDGE_SAMPLING_SUPPORT (1)
+/* @brief Peripheral type. */
+#define FSL_FEATURE_LPUART_IS_SCI (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPUART_FIFO_SIZEn(x) (16)
+/* @brief Supports two match addresses to filter incoming frames. */
+#define FSL_FEATURE_LPUART_HAS_ADDRESS_MATCHING (1)
+/* @brief Has transmitter/receiver DMA enable bits C5[TDMAE]/C5[RDMAE] (or BAUD[TDMAE]/BAUD[RDMAE] if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_DMA_ENABLE (1)
+/* @brief Has transmitter/receiver DMA select bits C4[TDMAS]/C4[RDMAS], resp. C5[TDMAS]/C5[RDMAS] if IS_SCI = 0. */
+#define FSL_FEATURE_LPUART_HAS_DMA_SELECT (0)
+/* @brief Data character bit order selection is supported (bit field S2[MSBF] or STAT[MSBF] if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_BIT_ORDER_SELECT (1)
+/* @brief Has smart card (ISO7816 protocol) support and no improved smart card support. */
+#define FSL_FEATURE_LPUART_HAS_SMART_CARD_SUPPORT (0)
+/* @brief Has improved smart card (ISO7816 protocol) support. */
+#define FSL_FEATURE_LPUART_HAS_IMPROVED_SMART_CARD_SUPPORT (0)
+/* @brief Has local operation network (CEA709.1-B protocol) support. */
+#define FSL_FEATURE_LPUART_HAS_LOCAL_OPERATION_NETWORK_SUPPORT (0)
+/* @brief Has 32-bit registers (BAUD, STAT, CTRL, DATA, MATCH, MODIR) instead of 8-bit (BDH, BDL, C1, S1, D, etc.). */
+#define FSL_FEATURE_LPUART_HAS_32BIT_REGISTERS (1)
+/* @brief Lin break detect available (has bit BAUD[LBKDIE]). */
+#define FSL_FEATURE_LPUART_HAS_LIN_BREAK_DETECT (1)
+/* @brief UART stops in Wait mode available (has bit C1[UARTSWAI]). */
+#define FSL_FEATURE_LPUART_HAS_WAIT_MODE_OPERATION (0)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPUART_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Has separate RX and TX interrupts. */
+#define FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ (0)
+/* @brief Has LPAURT_PARAM. */
+#define FSL_FEATURE_LPUART_HAS_PARAM (1)
+/* @brief Has LPUART_VERID. */
+#define FSL_FEATURE_LPUART_HAS_VERID (1)
+/* @brief Has LPUART_GLOBAL. */
+#define FSL_FEATURE_LPUART_HAS_GLOBAL (1)
+/* @brief Has LPUART_PINCFG. */
+#define FSL_FEATURE_LPUART_HAS_PINCFG (1)
+
+/* MEMORY module features */
+
+/* @brief Memory map has offset between subsystems. */
+#define FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET (1)
+
+/* PDM module features */
+
+/* @brief PDM FIFO offset */
+#define FSL_FEATURE_PDM_FIFO_OFFSET (4)
+/* @brief PDM Channel Number */
+#define FSL_FEATURE_PDM_CHANNEL_NUM (8)
+/* @brief PDM FIFO WIDTH Size */
+#define FSL_FEATURE_PDM_FIFO_WIDTH (4)
+/* @brief PDM FIFO DEPTH Size */
+#define FSL_FEATURE_PDM_FIFO_DEPTH (8)
+/* @brief PDM has RANGE_CTRL register */
+#define FSL_FEATURE_PDM_HAS_RANGE_CTRL (1)
+/* @brief PDM Has Low Frequency */
+#define FSL_FEATURE_PDM_HAS_STATUS_LOW_FREQ (1)
+/* @brief CLKDIV factor in Medium, High and Low Quality modes */
+#define FSL_FEATURE_PDM_HIGH_QUALITY_CLKDIV_FACTOR (93)
+/* @brief CLKDIV factor in Very Low Quality modes */
+#define FSL_FEATURE_PDM_VERY_LOW_QUALITY_CLKDIV_FACTOR (43)
+/* @brief PDM Has No VADEF Bitfield In PDM VAD0_STAT Register */
+#define FSL_FEATURE_PDM_HAS_NO_VADEF (0)
+/* @brief PDM Has no FIR_RDY Bitfield In PDM STAT Register */
+#define FSL_FEATURE_PDM_HAS_NO_FIR_RDY (1)
+
+/* SAI module features */
+
+/* @brief SAI has FIFO in this soc (register bit fields TCR1[TFW]. */
+#define FSL_FEATURE_SAI_HAS_FIFO (1)
+/* @brief Receive/transmit FIFO size in item count (register bit fields TCSR[FRDE], TCSR[FRIE], TCSR[FRF], TCR1[TFW], RCSR[FRDE], RCSR[FRIE], RCSR[FRF], RCR1[RFW], registers TFRn, RFRn). */
+#define FSL_FEATURE_SAI_FIFO_COUNTn(x) \
+    (((x) == SAI1) ? (32) : \
+    (((x) == SAI2) ? (128) : \
+    (((x) == SAI3) ? (128) : (-1))))
+/* @brief Receive/transmit channel number (register bit fields TCR3[TCE], RCR3[RCE], registers TDRn and RDRn). */
+#define FSL_FEATURE_SAI_CHANNEL_COUNTn(x) \
+    (((x) == SAI1) ? (2) : \
+    (((x) == SAI2) ? (4) : \
+    (((x) == SAI3) ? (1) : (-1))))
+/* @brief Maximum words per frame (register bit fields TCR3[WDFL], TCR4[FRSZ], TMR[TWM], RCR3[WDFL], RCR4[FRSZ], RMR[RWM]). */
+#define FSL_FEATURE_SAI_MAX_WORDS_PER_FRAME (32)
+/* @brief Has support of combining multiple data channel FIFOs into single channel FIFO (register bit fields TCR3[CFR], TCR4[FCOMB], TFR0[WCP], TFR1[WCP], RCR3[CFR], RCR4[FCOMB], RFR0[RCP], RFR1[RCP]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE (1)
+/* @brief Has packing of 8-bit and 16-bit data into each 32-bit FIFO word (register bit fields TCR4[FPACK], RCR4[FPACK]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_PACKING (1)
+/* @brief Configures when the SAI will continue transmitting after a FIFO error has been detected (register bit fields TCR4[FCONT], RCR4[FCONT]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR (1)
+/* @brief Configures if the frame sync is generated internally, a frame sync is only generated when the FIFO warning flag is clear or continuously (register bit fields TCR4[ONDEM], RCR4[ONDEM]). */
+#define FSL_FEATURE_SAI_HAS_ON_DEMAND_MODE (1)
+/* @brief Simplified bit clock source and asynchronous/synchronous mode selection (register bit fields TCR2[CLKMODE], RCR2[CLKMODE]), in comparison with the exclusively implemented TCR2[SYNC,BCS,BCI,MSEL], RCR2[SYNC,BCS,BCI,MSEL]. */
+#define FSL_FEATURE_SAI_HAS_CLOCKING_MODE (0)
+/* @brief Has register for configuration of the MCLK divide ratio (register bit fields MDR[FRACT], MDR[DIVIDE]). */
+#define FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER (0)
+/* @brief Has register of MCR. */
+#define FSL_FEATURE_SAI_HAS_MCR (1)
+/* @brief Has bit field MICS of the MCR register. */
+#define FSL_FEATURE_SAI_HAS_NO_MCR_MICS (1)
+/* @brief Has register of MDR */
+#define FSL_FEATURE_SAI_HAS_MDR (0)
+/* @brief Has support the BCLK bypass mode when BCLK = MCLK. */
+#define FSL_FEATURE_SAI_HAS_BCLK_BYPASS (1)
+/* @brief Has DIV bit fields of MCR register (register bit fields MCR[DIV]. */
+#define FSL_FEATURE_SAI_HAS_MCR_MCLK_POST_DIV (1)
+/* @brief Support Channel Mode (register bit fields TCR4[CHMOD]). */
+#define FSL_FEATURE_SAI_HAS_CHANNEL_MODE (1)
+
+/* SEMA42 module features */
+
+/* @brief Gate counts */
+#define FSL_FEATURE_SEMA42_GATE_COUNT (64)
+
+/* TPM module features */
+
+/* @brief Number of channels. */
+#define FSL_FEATURE_TPM_CHANNEL_COUNTn(x) (4)
+/* @brief Has counter reset by the selected input capture event (register bits C0SC[ICRST], C1SC[ICRST], ...). */
+#define FSL_FEATURE_TPM_HAS_COUNTER_RESET_BY_CAPTURE_EVENT (0)
+/* @brief Has TPM_PARAM. */
+#define FSL_FEATURE_TPM_HAS_PARAM (1)
+/* @brief Has TPM_VERID. */
+#define FSL_FEATURE_TPM_HAS_VERID (1)
+/* @brief Has TPM_GLOBAL. */
+#define FSL_FEATURE_TPM_HAS_GLOBAL (1)
+/* @brief Has TPM_TRIG. */
+#define FSL_FEATURE_TPM_HAS_TRIG (1)
+/* @brief Whether TRIG register has effect. */
+#define FSL_FEATURE_TPM_TRIG_HAS_EFFECTn(x) (0)
+/* @brief Has counter pause on trigger. */
+#define FSL_FEATURE_TPM_HAS_PAUSE_COUNTER_ON_TRIGGER (1)
+/* @brief Has external trigger selection. */
+#define FSL_FEATURE_TPM_HAS_EXTERNAL_TRIGGER_SELECTION (1)
+/* @brief Has TPM_COMBINE register. */
+#define FSL_FEATURE_TPM_HAS_COMBINE (1)
+/* @brief Whether COMBINE register has effect. */
+#define FSL_FEATURE_TPM_COMBINE_HAS_EFFECTn(x) (1)
+/* @brief Has TPM_POL. */
+#define FSL_FEATURE_TPM_HAS_POL (1)
+/* @brief Whether POL register has effect. */
+#define FSL_FEATURE_TPM_POL_HAS_EFFECTn(x) (0)
+/* @brief Has TPM_FILTER register. */
+#define FSL_FEATURE_TPM_HAS_FILTER (1)
+/* @brief Whether FILTER register has effect. */
+#define FSL_FEATURE_TPM_FILTER_HAS_EFFECTn(x) (1)
+/* @brief Has TPM_QDCTRL register. */
+#define FSL_FEATURE_TPM_HAS_QDCTRL (1)
+/* @brief Whether QDCTRL register has effect. */
+#define FSL_FEATURE_TPM_QDCTRL_HAS_EFFECTn(x) (1)
+/* @brief Has pause level select. */
+#define FSL_FEATURE_TPM_HAS_PAUSE_LEVEL_SELECT (1)
+/* @brief Whether 32 bits counter has effect. */
+#define FSL_FEATURE_TPM_HAS_32BIT_COUNTERn(x) (1)
+
+/* TRDC module features */
+
+/* @brief Process master count. */
+#define FSL_FEATURE_TRDC_PROCESSOR_MASTER_COUNT (2)
+/* @brief TRDC instance has PID configuration or not. */
+#define FSL_FEATURE_TRDC_INSTANCE_HAS_PID_CONFIGURATIONn(x) \
+    (((x) == TRDC1) ? (1) : \
+    (((x) == TRDC2) ? (0) : (-1)))
+/* @brief TRDC domain number (reset value of HWCFG0[NDID]). */
+#define FSL_FEATURE_TRDC_DOMAIN_COUNT (16)
+
+/* TSTMR module features */
+
+/* @brief TSTMR clock frequency is 1MHZ. */
+#define FSL_FEATURE_TSTMR_CLOCK_FREQUENCY_1MHZ (1)
+
+/* USDHC module features */
+
+/* @brief Has external DMA support (VEND_SPEC[EXT_DMA_EN]) */
+#define FSL_FEATURE_USDHC_HAS_EXT_DMA (0)
+/* @brief Has HS400 mode (MIX_CTRL[HS400_MODE]) */
+#define FSL_FEATURE_USDHC_HAS_HS400_MODE (1)
+/* @brief Has SDR50 support (HOST_CTRL_CAP[SDR50_SUPPORT]) */
+#define FSL_FEATURE_USDHC_HAS_SDR50_MODE (1)
+/* @brief Has SDR104 support (HOST_CTRL_CAP[SDR104_SUPPORT]) */
+#define FSL_FEATURE_USDHC_HAS_SDR104_MODE (1)
+/* @brief USDHC has reset control */
+#define FSL_FEATURE_USDHC_HAS_RESET (0)
+/* @brief USDHC has no bitfield WTMK_LVL[WR_BRST_LEN] and WTMK_LVL[RD_BRST_LEN] */
+#define FSL_FEATURE_USDHC_HAS_NO_RW_BURST_LEN (1)
+/* @brief If USDHC instance support 8 bit width */
+#define FSL_FEATURE_USDHC_INSTANCE_SUPPORT_8_BIT_WIDTHn(x) (1)
+/* @brief If USDHC instance support HS400 mode */
+#define FSL_FEATURE_USDHC_INSTANCE_SUPPORT_HS400_MODEn(x) (0)
+/* @brief If USDHC instance support 1v8 signal */
+#define FSL_FEATURE_USDHC_INSTANCE_SUPPORT_1V8_SIGNALn(x) (1)
+/* @brief Has no retuning time counter (HOST_CTRL_CAP[TIME_COUNT_RETURNING]) */
+#define FSL_FEATURE_USDHC_REGISTER_HOST_CTRL_CAP_HAS_NO_RETUNING_TIME_COUNTER (1)
+
+/* WDOG module features */
+
+/* @brief Watchdog is available. */
+#define FSL_FEATURE_WDOG_HAS_WATCHDOG (1)
+/* @brief WDOG_CNT can be 32-bit written. */
+#define FSL_FEATURE_WDOG_HAS_32BIT_ACCESS (1)
+
+#endif /* _MIMX9352_ca55_FEATURES_H_ */
+

--- a/devices/MIMX9352/MIMX9352_cm33_features.h
+++ b/devices/MIMX9352/MIMX9352_cm33_features.h
@@ -1,0 +1,604 @@
+/*
+** ###################################################################
+**     Version:             rev. 1.0, 2021-11-16
+**     Build:               b220830
+**
+**     Abstract:
+**         Chip specific module features.
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2022 NXP
+**     All rights reserved.
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+**     Revisions:
+**     - rev. 1.0 (2021-11-16)
+**         Initial version.
+**
+** ###################################################################
+*/
+
+#ifndef _MIMX9352_cm33_FEATURES_H_
+#define _MIMX9352_cm33_FEATURES_H_
+
+/* SOC module features */
+
+/* @brief AXBS availability on the SoC. */
+#define FSL_FEATURE_SOC_AXBS_COUNT (1)
+/* @brief DDR availability on the SoC. */
+#define FSL_FEATURE_SOC_DDR_COUNT (1)
+/* @brief DMA4 availability on the SoC. */
+#define FSL_FEATURE_SOC_DMA4_COUNT (1)
+/* @brief EDMA availability on the SoC. */
+#define FSL_FEATURE_SOC_EDMA_COUNT (1)
+/* @brief ENET availability on the SoC. */
+#define FSL_FEATURE_SOC_ENET_COUNT (1)
+/* @brief ENET_QOS availability on the SoC. */
+#define FSL_FEATURE_SOC_ENET_QOS_COUNT (1)
+/* @brief FLEXCAN availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXCAN_COUNT (2)
+/* @brief FLEXIO availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXIO_COUNT (2)
+/* @brief FLEXSPI availability on the SoC. */
+#define FSL_FEATURE_SOC_FLEXSPI_COUNT (1)
+/* @brief GPC availability on the SoC. */
+#define FSL_FEATURE_SOC_GPC_COUNT (4)
+/* @brief I3C availability on the SoC. */
+#define FSL_FEATURE_SOC_I3C_COUNT (2)
+/* @brief I2S availability on the SoC. */
+#define FSL_FEATURE_SOC_I2S_COUNT (3)
+/* @brief ISI availability on the SoC. */
+#define FSL_FEATURE_SOC_ISI_COUNT (1)
+/* @brief LCDIF availability on the SoC. */
+#define FSL_FEATURE_SOC_LCDIF_COUNT (1)
+/* @brief LPI2C availability on the SoC. */
+#define FSL_FEATURE_SOC_LPI2C_COUNT (8)
+/* @brief LPIT availability on the SoC. */
+#define FSL_FEATURE_SOC_LPIT_COUNT (2)
+/* @brief LPSPI availability on the SoC. */
+#define FSL_FEATURE_SOC_LPSPI_COUNT (8)
+/* @brief LPTMR availability on the SoC. */
+#define FSL_FEATURE_SOC_LPTMR_COUNT (2)
+/* @brief LPUART availability on the SoC. */
+#define FSL_FEATURE_SOC_LPUART_COUNT (8)
+/* @brief MCM availability on the SoC. */
+#define FSL_FEATURE_SOC_MCM_COUNT (1)
+/* @brief MIPI_DSI availability on the SoC. */
+#define FSL_FEATURE_SOC_MIPI_DSI_COUNT (1)
+/* @brief MU availability on the SoC. */
+#define FSL_FEATURE_SOC_MU_COUNT (2)
+/* @brief NPU availability on the SoC. */
+#define FSL_FEATURE_SOC_NPU_COUNT (1)
+/* @brief OCOTP availability on the SoC. */
+#define FSL_FEATURE_SOC_OCOTP_COUNT (1)
+/* @brief OTFAD availability on the SoC. */
+#define FSL_FEATURE_SOC_OTFAD_COUNT (1)
+/* @brief PDM availability on the SoC. */
+#define FSL_FEATURE_SOC_PDM_COUNT (1)
+/* @brief PXP availability on the SoC. */
+#define FSL_FEATURE_SOC_PXP_COUNT (1)
+/* @brief RGPIO availability on the SoC. */
+#define FSL_FEATURE_SOC_RGPIO_COUNT (4)
+/* @brief ROMC availability on the SoC. */
+#define FSL_FEATURE_SOC_ROMC_COUNT (2)
+/* @brief SEMA42 availability on the SoC. */
+#define FSL_FEATURE_SOC_SEMA42_COUNT (2)
+/* @brief SFA availability on the SoC. */
+#define FSL_FEATURE_SOC_SFA_COUNT (1)
+/* @brief SPDIF availability on the SoC. */
+#define FSL_FEATURE_SOC_SPDIF_COUNT (1)
+/* @brief SRC availability on the SoC. */
+#define FSL_FEATURE_SOC_SRC_COUNT (13)
+/* @brief TPM availability on the SoC. */
+#define FSL_FEATURE_SOC_TPM_COUNT (6)
+/* @brief TRGMUX availability on the SoC. */
+#define FSL_FEATURE_SOC_TRGMUX_COUNT (1)
+/* @brief TSTMR availability on the SoC. */
+#define FSL_FEATURE_SOC_TSTMR_COUNT (2)
+/* @brief USB availability on the SoC. */
+#define FSL_FEATURE_SOC_USB_COUNT (2)
+/* @brief USBNC availability on the SoC. */
+#define FSL_FEATURE_SOC_USBNC_COUNT (2)
+/* @brief USDHC availability on the SoC. */
+#define FSL_FEATURE_SOC_USDHC_COUNT (3)
+/* @brief WDOG availability on the SoC. */
+#define FSL_FEATURE_SOC_WDOG_COUNT (5)
+/* @brief XCACHE availability on the SoC. */
+#define FSL_FEATURE_SOC_XCACHE_COUNT (2)
+
+/* FLEXCAN module features */
+
+/* @brief Message buffer size */
+#define FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(x) (96)
+/* @brief Has doze mode support (register bit field MCR[DOZE]). */
+#define FSL_FEATURE_FLEXCAN_HAS_DOZE_MODE_SUPPORT (1)
+/* @brief Insatnce has doze mode support (register bit field MCR[DOZE]). */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_DOZE_MODE_SUPPORTn(x) (1)
+/* @brief Has a glitch filter on the receive pin (register bit field MCR[WAKSRC]). */
+#define FSL_FEATURE_FLEXCAN_HAS_GLITCH_FILTER (1)
+/* @brief Has extended interrupt mask and flag register (register IMASK2, IFLAG2). */
+#define FSL_FEATURE_FLEXCAN_HAS_EXTENDED_FLAG_REGISTER (1)
+/* @brief Instance has extended bit timing register (register CBT). */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_EXTENDED_TIMING_REGISTERn(x) (1)
+/* @brief Has a receive FIFO DMA feature (register bit field MCR[DMA]). */
+#define FSL_FEATURE_FLEXCAN_HAS_RX_FIFO_DMA (1)
+/* @brief Instance has a receive FIFO DMA feature (register bit field MCR[DMA]). */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_RX_FIFO_DMAn(x) (1)
+/* @brief Remove CAN Engine Clock Source Selection from unsupported part. */
+#define FSL_FEATURE_FLEXCAN_SUPPORT_ENGINE_CLK_SEL_REMOVE (0)
+/* @brief Instance remove CAN Engine Clock Source Selection from unsupported part. */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_SUPPORT_ENGINE_CLK_SEL_REMOVEn(x) (0)
+/* @brief Is affected by errata with ID 5641 (Module does not transmit a message that is enabled to be transmitted at a
+ * specific moment during the arbitration process). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_5641 (0)
+/* @brief Is affected by errata with ID 5829 (FlexCAN: FlexCAN does not transmit a message that is enabled to be
+ * transmitted in a specific moment during the arbitration process). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_5829 (0)
+/* @brief Is affected by errata with ID 6032 (FlexCAN: A frame with wrong ID or payload is transmitted into the CAN bus
+ * when the Message Buffer under transmission is either aborted or deactivated while the CAN bus is in the Bus Idle
+ * state). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_6032 (0)
+/* @brief Is affected by errata with ID 9595 (FlexCAN: Corrupt frame possible if the Freeze Mode or the Low-Power Mode
+ * are entered during a Bus-Off state). */
+#define FSL_FEATURE_FLEXCAN_HAS_ERRATA_9595 (0)
+/* @brief Has CAN with Flexible Data rate (CAN FD) protocol. */
+#define FSL_FEATURE_FLEXCAN_HAS_FLEXIBLE_DATA_RATE (1)
+/* @brief CAN instance support Flexible Data rate (CAN FD) protocol. */
+#define FSL_FEATURE_FLEXCAN_INSTANCE_HAS_FLEXIBLE_DATA_RATEn(x) (1)
+/* @brief Has memory error control (register MECR). */
+#define FSL_FEATURE_FLEXCAN_HAS_MEMORY_ERROR_CONTROL (1)
+/* @brief Init memory base 1 */
+#define FSL_FEATURE_FLEXCAN_INIT_MEMORY_BASE_1 (0x80)
+/* @brief Init memory size 1 */
+#define FSL_FEATURE_FLEXCAN_INIT_MEMORY_SIZE_1 (0xA60)
+/* @brief Init memory base 2 */
+#define FSL_FEATURE_FLEXCAN_INIT_MEMORY_BASE_2 (0xC20)
+/* @brief Init memory size 2 */
+#define FSL_FEATURE_FLEXCAN_INIT_MEMORY_SIZE_2 (0x25E0)
+/* @brief Has enhanced bit timing register (register EPRS, ENCBT, EDCBT and ETDC). */
+#define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_BIT_TIMING_REG (1)
+/* @brief Has Pretended Networking mode support. */
+#define FSL_FEATURE_FLEXCAN_HAS_PN_MODE (0)
+/* @brief Has Enhanced Rx FIFO. */
+#define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_RX_FIFO (1)
+/* @brief Enhanced Rx FIFO size (Indicates how many CAN FD messages can be stored). */
+#define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_RX_FIFO_SIZE (20)
+/* @brief The number of enhanced Rx FIFO filter element registers. */
+#define FSL_FEATURE_FLEXCAN_HAS_ENHANCED_RX_FIFO_FILTER_MAX_NUMBER (128)
+/* @brief Does not support Supervisor Mode (bitfield MCR[SUPV]. */
+#define FSL_FEATURE_FLEXCAN_HAS_NO_SUPV_SUPPORT (0)
+
+/* EDMA module features */
+
+/* @brief Number of DMA channels (related to number of registers TCD, DCHPRI, bit fields ERQ[ERQn], EEI[EEIn],
+ * INT[INTn], ERR[ERRn], HRS[HRSn] and bit field widths ES[ERRCHN], CEEI[CEEI], SEEI[SEEI], CERQ[CERQ], SERQ[SERQ],
+ * CDNE[CDNE], SSRT[SSRT], CERR[CERR], CINT[CINT], TCDn_CITER_ELINKYES[LINKCH], TCDn_CSR[MAJORLINKCH],
+ * TCDn_BITER_ELINKYES[LINKCH]). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_MODULE_CHANNEL (31)
+/* @brief Total number of DMA channels on all modules. */
+#define FSL_FEATURE_EDMA_DMAMUX_CHANNELS (31)
+/* @brief Number of DMA channel groups (register bit fields CR[ERGA], CR[GRPnPRI], ES[GPE], DCHPRIn[GRPPRI]). (Valid
+ * only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_CHANNEL_GROUP_COUNT (1)
+/* @brief Has DMA_Error interrupt vector. */
+#define FSL_FEATURE_EDMA_HAS_ERROR_IRQ (1)
+/* @brief Number of DMA channels with asynchronous request capability (register EARS). (Valid only for eDMA modules.) */
+#define FSL_FEATURE_EDMA_ASYNCHRO_REQUEST_CHANNEL_COUNT (32)
+/* @brief If channel clock controlled independently */
+#define FSL_FEATURE_EDMA_CHANNEL_HAS_OWN_CLOCK_GATE (1)
+/* @brief Number of channel for each EDMA instance, (only defined for soc with different channel numbers for difference
+ * instance) */
+#define FSL_FEATURE_EDMA_INSTANCE_CHANNELn(x) (31)
+/* @brief Has no register bit fields MP_CSR[EBW]. */
+#define FSL_FEATURE_EDMA_HAS_NO_MP_CSR_EBW (1)
+/* @brief If dma has channel mux */
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_MUX (0)
+/* @brief If dma has common clock gate */
+#define FSL_FEATURE_EDMA_HAS_COMMON_CLOCK_GATE (0)
+/* @brief If dma channel IRQ support parameter */
+#define FSL_FEATURE_EDMA_MODULE_CHANNEL_IRQ_ENTRY_SUPPORT_PARAMETER (0)
+/* @brief If 8 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_8_BYTES_TRANSFER (1)
+/* @brief If 16 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_16_BYTES_TRANSFER (1)
+/* @brief If 64 bytes transfer supported. */
+#define FSL_FEATURE_EDMA_SUPPORT_64_BYTES_TRANSFER (1)
+
+/* DMA_TCD module features */
+
+/* @brief Has no supervisor access bit (CR). */
+#define FSL_FEATURE_DMA_TCD_HAS_NO_CR_SUP (1)
+/* @brief Has no oscillator enable bit (CR). */
+#define FSL_FEATURE_DMA_TCD_HAS_NO_CR_OSCE (1)
+
+/* ENET module features */
+
+/* @brief Support Interrupt Coalesce */
+#define FSL_FEATURE_ENET_HAS_INTERRUPT_COALESCE (1)
+/* @brief Queue Size. */
+#define FSL_FEATURE_ENET_QUEUE (3)
+/* @brief Has AVB Support. */
+#define FSL_FEATURE_ENET_HAS_AVB (1)
+/* @brief Has Timer Pulse Width control. */
+#define FSL_FEATURE_ENET_HAS_TIMER_PWCONTROL (0)
+/* @brief Has Extend MDIO Support. */
+#define FSL_FEATURE_ENET_HAS_EXTEND_MDIO (1)
+/* @brief Has Additional 1588 Timer Channel Interrupt. */
+#define FSL_FEATURE_ENET_HAS_ADD_1588_TIMER_CHN_INT (0)
+/* @brief Support Interrupt Coalesce for each instance */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_INTERRUPT_COALESCEn(x) (1)
+/* @brief Queue Size for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_QUEUEn(x) (3)
+/* @brief Has AVB Support for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_AVBn(x) (1)
+/* @brief Has Timer Pulse Width control for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_TIMER_PWCONTROLn(x) (0)
+/* @brief Has Extend MDIO Support for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_EXTEND_MDIOn(x) (1)
+/* @brief Has Additional 1588 Timer Channel Interrupt for each instance. */
+#define FSL_FEATURE_ENET_INSTANCE_HAS_ADD_1588_TIMER_CHN_INTn(x) (0)
+/* @brief Has threshold for the number of frames in the receive FIFO (register bit field RSEM[STAT_SECTION_EMPTY]). */
+#define FSL_FEATURE_ENET_HAS_RECEIVE_STATUS_THRESHOLD (1)
+/* @brief Has trasfer clock delay (register bit field ECR[TXC_DLY]). */
+#define FSL_FEATURE_ENET_HAS_RGMII_TXC_DELAY (1)
+/* @brief Has receive clock delay (register bit field ECR[RXC_DLY]). */
+#define FSL_FEATURE_ENET_HAS_RGMII_RXC_DELAY (1)
+/* @brief PTP Timestamp CAPTURE bit always returns 0 when the capture is not over. */
+#define FSL_FEATURE_ENET_TIMESTAMP_CAPTURE_BIT_INVALID (0)
+/* @brief ENET Has Extra Clock Gate.(RW610). */
+#define FSL_FEATURE_ENET_HAS_EXTRA_CLOCK_GATE (0)
+
+/* ENET_QOS module features */
+
+/* No feature definitions */
+
+/* FLEXSPI module features */
+
+/* @brief FlexSPI AHB buffer count */
+#define FSL_FEATURE_FLEXSPI_AHB_BUFFER_COUNTn(x) (8)
+/* @brief FlexSPI has no MCR0 ARDFEN bit */
+#define FSL_FEATURE_FLEXSPI_HAS_NO_MCR0_ARDFEN (0)
+/* @brief FlexSPI has no MCR0 ATDFEN bit */
+#define FSL_FEATURE_FLEXSPI_HAS_NO_MCR0_ATDFEN (0)
+
+/* RGPIO module features */
+
+/* @brief Has GPIO attribute checker register  (GACR). */
+#define FSL_FEATURE_RGPIO_HAS_ATTRIBUTE_CHECKER (0)
+/* @brief There is ICR registers */
+#define FSL_FEATURE_RGPIO_HAS_IRQ_CONFIG (1)
+/* @brief There is PIDR register */
+#define FSL_FEATURE_RGPIO_HAS_PORT_INPUT_DISABLE (1)
+
+/* I3C module features */
+
+/* @brief Has TERM bitfile in MERRWARN register. */
+#define FSL_FEATURE_I3C_HAS_NO_MERRWARN_TERM (0)
+/* @brief SOC has no reset driver. */
+#define FSL_FEATURE_I3C_HAS_NO_RESET (1)
+/* @brief Use fixed BAMATCH count, do not provide editable BAMATCH. */
+#define FSL_FEATURE_I3C_HAS_NO_SCONFIG_BAMATCH (0)
+/* @brief Register SCONFIG do not have IDRAND bitfield. */
+#define FSL_FEATURE_I3C_HAS_NO_SCONFIG_IDRAND (1)
+/* @brief Register SCONFIG has HDROK bitfield. */
+#define FSL_FEATURE_I3C_HAS_HDROK (1)
+
+/* XCACHE module features */
+
+/* @brief Cache Line size in byte. */
+#define FSL_FEATURE_XCACHE_LINESIZE_BYTE (16)
+/* @brief Cache doesn't support write buffer. */
+#define FSL_FEATURE_XCACHE_HAS_NO_WRITE_BUF (1)
+
+/* LPI2C module features */
+
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPI2C_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPI2C_FIFO_SIZEn(x) (8)
+
+/* LPIT module features */
+
+/* @brief Number of channels (related to number of registers LDVALn, CVALn, TCTRLn, TFLGn). */
+#define FSL_FEATURE_LPIT_TIMER_COUNT (4)
+/* @brief Has lifetime timer (related to existence of registers LTMR64L and LTMR64H). */
+#define FSL_FEATURE_LPIT_HAS_LIFETIME_TIMER (0)
+/* @brief Has shared interrupt handler (has not individual interrupt handler for each channel). */
+#define FSL_FEATURE_LPIT_HAS_SHARED_IRQ_HANDLER (1)
+
+/* LPSPI module features */
+
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPSPI_FIFO_SIZEn(x) (8)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPSPI_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Has CCR1 (related to existence of registers CCR1). */
+#define FSL_FEATURE_LPSPI_HAS_CCR1 (1)
+
+/* LPTMR module features */
+
+/* @brief Has shared interrupt handler with another LPTMR module. */
+#define FSL_FEATURE_LPTMR_HAS_SHARED_IRQ_HANDLER (0)
+/* @brief Whether LPTMR counter is 32 bits width. */
+#define FSL_FEATURE_LPTMR_CNR_WIDTH_IS_32B (1)
+/* @brief Has timer DMA request enable (register bit CSR[TDRE]). */
+#define FSL_FEATURE_LPTMR_HAS_CSR_TDRE (1)
+/* @brief Do not has prescaler clock source 1. */
+#define FSL_FEATURE_LPTMR_HAS_NO_PRESCALER_CLOCK_SOURCE_1_SUPPORT (0)
+/* @brief Do not has prescaler clock source 3. */
+#define FSL_FEATURE_LPTMR_HAS_NO_PRESCALER_CLOCK_SOURCE_3_SUPPORT (0)
+
+/* LPUART module features */
+
+/* @brief Has receive FIFO overflow detection (bit field CFIFO[RXOFE]). */
+#define FSL_FEATURE_LPUART_HAS_IRQ_EXTENDED_FUNCTIONS (0)
+/* @brief Has low power features (can be enabled in wait mode via register bit C1[DOZEEN] or CTRL[DOZEEN] if the
+ * registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_LOW_POWER_UART_SUPPORT (1)
+/* @brief Has extended data register ED (or extra flags in the DATA register if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_EXTENDED_DATA_REGISTER_FLAGS (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPUART_HAS_FIFO (1)
+/* @brief Has 32-bit register MODIR */
+#define FSL_FEATURE_LPUART_HAS_MODIR (1)
+/* @brief Hardware flow control (RTS, CTS) is supported. */
+#define FSL_FEATURE_LPUART_HAS_MODEM_SUPPORT (1)
+/* @brief Infrared (modulation) is supported. */
+#define FSL_FEATURE_LPUART_HAS_IR_SUPPORT (1)
+/* @brief 2 bits long stop bit is available. */
+#define FSL_FEATURE_LPUART_HAS_STOP_BIT_CONFIG_SUPPORT (1)
+/* @brief If 10-bit mode is supported. */
+#define FSL_FEATURE_LPUART_HAS_10BIT_DATA_SUPPORT (1)
+/* @brief If 7-bit mode is supported. */
+#define FSL_FEATURE_LPUART_HAS_7BIT_DATA_SUPPORT (1)
+/* @brief Baud rate fine adjustment is available. */
+#define FSL_FEATURE_LPUART_HAS_BAUD_RATE_FINE_ADJUST_SUPPORT (0)
+/* @brief Baud rate oversampling is available (has bit fields C4[OSR], C5[BOTHEDGE], C5[RESYNCDIS] or BAUD[OSR],
+ * BAUD[BOTHEDGE], BAUD[RESYNCDIS] if the registers are 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_BAUD_RATE_OVER_SAMPLING_SUPPORT (1)
+/* @brief Baud rate oversampling is available. */
+#define FSL_FEATURE_LPUART_HAS_RX_RESYNC_SUPPORT (1)
+/* @brief Baud rate oversampling is available. */
+#define FSL_FEATURE_LPUART_HAS_BOTH_EDGE_SAMPLING_SUPPORT (1)
+/* @brief Peripheral type. */
+#define FSL_FEATURE_LPUART_IS_SCI (1)
+/* @brief Capacity (number of entries) of the transmit/receive FIFO (or zero if no FIFO is available). */
+#define FSL_FEATURE_LPUART_FIFO_SIZEn(x) (16)
+/* @brief Supports two match addresses to filter incoming frames. */
+#define FSL_FEATURE_LPUART_HAS_ADDRESS_MATCHING (1)
+/* @brief Has transmitter/receiver DMA enable bits C5[TDMAE]/C5[RDMAE] (or BAUD[TDMAE]/BAUD[RDMAE] if the registers are
+ * 32-bit wide). */
+#define FSL_FEATURE_LPUART_HAS_DMA_ENABLE (1)
+/* @brief Has transmitter/receiver DMA select bits C4[TDMAS]/C4[RDMAS], resp. C5[TDMAS]/C5[RDMAS] if IS_SCI = 0. */
+#define FSL_FEATURE_LPUART_HAS_DMA_SELECT (0)
+/* @brief Data character bit order selection is supported (bit field S2[MSBF] or STAT[MSBF] if the registers are 32-bit
+ * wide). */
+#define FSL_FEATURE_LPUART_HAS_BIT_ORDER_SELECT (1)
+/* @brief Has smart card (ISO7816 protocol) support and no improved smart card support. */
+#define FSL_FEATURE_LPUART_HAS_SMART_CARD_SUPPORT (0)
+/* @brief Has improved smart card (ISO7816 protocol) support. */
+#define FSL_FEATURE_LPUART_HAS_IMPROVED_SMART_CARD_SUPPORT (0)
+/* @brief Has local operation network (CEA709.1-B protocol) support. */
+#define FSL_FEATURE_LPUART_HAS_LOCAL_OPERATION_NETWORK_SUPPORT (0)
+/* @brief Has 32-bit registers (BAUD, STAT, CTRL, DATA, MATCH, MODIR) instead of 8-bit (BDH, BDL, C1, S1, D, etc.). */
+#define FSL_FEATURE_LPUART_HAS_32BIT_REGISTERS (1)
+/* @brief Lin break detect available (has bit BAUD[LBKDIE]). */
+#define FSL_FEATURE_LPUART_HAS_LIN_BREAK_DETECT (1)
+/* @brief UART stops in Wait mode available (has bit C1[UARTSWAI]). */
+#define FSL_FEATURE_LPUART_HAS_WAIT_MODE_OPERATION (0)
+/* @brief Has separate DMA RX and TX requests. */
+#define FSL_FEATURE_LPUART_HAS_SEPARATE_DMA_RX_TX_REQn(x) (1)
+/* @brief Has separate RX and TX interrupts. */
+#define FSL_FEATURE_LPUART_HAS_SEPARATE_RX_TX_IRQ (0)
+/* @brief Has LPAURT_PARAM. */
+#define FSL_FEATURE_LPUART_HAS_PARAM (1)
+/* @brief Has LPUART_VERID. */
+#define FSL_FEATURE_LPUART_HAS_VERID (1)
+/* @brief Has LPUART_GLOBAL. */
+#define FSL_FEATURE_LPUART_HAS_GLOBAL (1)
+/* @brief Has LPUART_PINCFG. */
+#define FSL_FEATURE_LPUART_HAS_PINCFG (1)
+
+/* MEMORY module features */
+
+/* @brief Memory map has offset between subsystems. */
+#define FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET (1)
+
+/* MU module features */
+
+/* @brief MU side for current core */
+#define FSL_FEATURE_MU_SIDE_A (1)
+/* @brief MU Has register CCR */
+#define FSL_FEATURE_MU_HAS_CCR (0)
+/* @brief MU Has register SR[RS], BSR[ARS] */
+#define FSL_FEATURE_MU_HAS_SR_RS (0)
+/* @brief MU Has register CR[RDIE], CR[RAIE], SR[RDIP], SR[RAIP] */
+#define FSL_FEATURE_MU_HAS_RESET_INT (0)
+/* @brief MU Has register SR[MURIP] */
+#define FSL_FEATURE_MU_HAS_SR_MURIP (1)
+/* @brief MU Has register SR[HRIP] */
+#define FSL_FEATURE_MU_HAS_SR_HRIP (0)
+/* @brief MU does not support enable clock of the other core, CR[CLKE] or CCR[CLKE]. */
+#define FSL_FEATURE_MU_NO_CLKE (1)
+/* @brief MU does not support NMI, CR[NMI]. */
+#define FSL_FEATURE_MU_NO_NMI (1)
+/* @brief MU does not support hold the other core reset. CR[RSTH] or CCR[RSTH]. */
+#define FSL_FEATURE_MU_NO_RSTH (1)
+/* @brief MU does not supports MU reset, CR[MUR]. */
+#define FSL_FEATURE_MU_NO_MUR (0)
+/* @brief MU does not supports hardware reset, CR[HR] or CCR[HR]. */
+#define FSL_FEATURE_MU_NO_HR (1)
+/* @brief MU supports mask the hardware reset. CR[HRM] or CCR[HRM]. */
+#define FSL_FEATURE_MU_HAS_HRM (0)
+/* @brief MU does not support check the other core power mode. SR[PM] or BSR[APM]. */
+#define FSL_FEATURE_MU_NO_PM (1)
+/* @brief MU supports reset assert interrupt. CR[RAIE] or BCR[RAIE]. */
+#define FSL_FEATURE_MU_HAS_RESET_ASSERT_INT (0)
+/* @brief MU supports reset de-assert interrupt. CR[RDIE] or BCR[RDIE]. */
+#define FSL_FEATURE_MU_HAS_RESET_DEASSERT_INT (0)
+
+/* PDM module features */
+
+/* @brief PDM FIFO offset */
+#define FSL_FEATURE_PDM_FIFO_OFFSET (4)
+/* @brief PDM Channel Number */
+#define FSL_FEATURE_PDM_CHANNEL_NUM (8)
+/* @brief PDM FIFO WIDTH Size */
+#define FSL_FEATURE_PDM_FIFO_WIDTH (4)
+/* @brief PDM FIFO DEPTH Size */
+#define FSL_FEATURE_PDM_FIFO_DEPTH (8)
+/* @brief PDM has RANGE_CTRL register */
+#define FSL_FEATURE_PDM_HAS_RANGE_CTRL (1)
+/* @brief PDM Has Low Frequency */
+#define FSL_FEATURE_PDM_HAS_STATUS_LOW_FREQ (1)
+/* @brief CLKDIV factor in Medium, High and Low Quality modes */
+#define FSL_FEATURE_PDM_HIGH_QUALITY_CLKDIV_FACTOR (93)
+/* @brief CLKDIV factor in Very Low Quality modes */
+#define FSL_FEATURE_PDM_VERY_LOW_QUALITY_CLKDIV_FACTOR (43)
+/* @brief PDM Has No VADEF Bitfield In PDM VAD0_STAT Register */
+#define FSL_FEATURE_PDM_HAS_NO_VADEF (0)
+
+/* SAI module features */
+
+/* @brief SAI has FIFO in this soc (register bit fields TCR1[TFW]. */
+#define FSL_FEATURE_SAI_HAS_FIFO (1)
+/* @brief Receive/transmit FIFO size in item count (register bit fields TCSR[FRDE], TCSR[FRIE], TCSR[FRF], TCR1[TFW],
+ * RCSR[FRDE], RCSR[FRIE], RCSR[FRF], RCR1[RFW], registers TFRn, RFRn). */
+#define FSL_FEATURE_SAI_FIFO_COUNTn(x) (((x) == SAI1) ? (32) : (((x) == SAI2) ? (128) : (((x) == SAI3) ? (128) : (-1))))
+/* @brief Receive/transmit channel number (register bit fields TCR3[TCE], RCR3[RCE], registers TDRn and RDRn). */
+#define FSL_FEATURE_SAI_CHANNEL_COUNTn(x) (((x) == SAI1) ? (2) : (((x) == SAI2) ? (4) : (((x) == SAI3) ? (1) : (-1))))
+/* @brief Maximum words per frame (register bit fields TCR3[WDFL], TCR4[FRSZ], TMR[TWM], RCR3[WDFL], RCR4[FRSZ],
+ * RMR[RWM]). */
+#define FSL_FEATURE_SAI_MAX_WORDS_PER_FRAME (32)
+/* @brief Has support of combining multiple data channel FIFOs into single channel FIFO (register bit fields TCR3[CFR],
+ * TCR4[FCOMB], TFR0[WCP], TFR1[WCP], RCR3[CFR], RCR4[FCOMB], RFR0[RCP], RFR1[RCP]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_COMBINE_MODE (1)
+/* @brief Has packing of 8-bit and 16-bit data into each 32-bit FIFO word (register bit fields TCR4[FPACK],
+ * RCR4[FPACK]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_PACKING (1)
+/* @brief Configures when the SAI will continue transmitting after a FIFO error has been detected (register bit fields
+ * TCR4[FCONT], RCR4[FCONT]). */
+#define FSL_FEATURE_SAI_HAS_FIFO_FUNCTION_AFTER_ERROR (1)
+/* @brief Configures if the frame sync is generated internally, a frame sync is only generated when the FIFO warning
+ * flag is clear or continuously (register bit fields TCR4[ONDEM], RCR4[ONDEM]). */
+#define FSL_FEATURE_SAI_HAS_ON_DEMAND_MODE (1)
+/* @brief Simplified bit clock source and asynchronous/synchronous mode selection (register bit fields TCR2[CLKMODE],
+ * RCR2[CLKMODE]), in comparison with the exclusively implemented TCR2[SYNC,BCS,BCI,MSEL], RCR2[SYNC,BCS,BCI,MSEL]. */
+#define FSL_FEATURE_SAI_HAS_CLOCKING_MODE (0)
+/* @brief Has register for configuration of the MCLK divide ratio (register bit fields MDR[FRACT], MDR[DIVIDE]). */
+#define FSL_FEATURE_SAI_HAS_MCLKDIV_REGISTER (0)
+/* @brief Interrupt source number */
+#define FSL_FEATURE_SAI_INT_SOURCE_NUM (1)
+/* @brief Has register of MCR. */
+#define FSL_FEATURE_SAI_HAS_MCR (1)
+/* @brief Has bit field MICS of the MCR register. */
+#define FSL_FEATURE_SAI_HAS_NO_MCR_MICS (1)
+/* @brief Has register of MDR */
+#define FSL_FEATURE_SAI_HAS_MDR (0)
+/* @brief Has support the BCLK bypass mode when BCLK = MCLK. */
+#define FSL_FEATURE_SAI_HAS_BCLK_BYPASS (1)
+/* @brief Has DIV bit fields of MCR register (register bit fields MCR[DIV]. */
+#define FSL_FEATURE_SAI_HAS_MCR_MCLK_POST_DIV (1)
+/* @brief Support Channel Mode (register bit fields TCR4[CHMOD]). */
+#define FSL_FEATURE_SAI_HAS_CHANNEL_MODE (1)
+
+/* SEMA42 module features */
+
+/* @brief Gate counts */
+#define FSL_FEATURE_SEMA42_GATE_COUNT (64)
+
+/* TPM module features */
+
+/* @brief Number of channels. */
+#define FSL_FEATURE_TPM_CHANNEL_COUNTn(x) (4)
+/* @brief Has counter reset by the selected input capture event (register bits C0SC[ICRST], C1SC[ICRST], ...). */
+#define FSL_FEATURE_TPM_HAS_COUNTER_RESET_BY_CAPTURE_EVENT (0)
+/* @brief Has TPM_PARAM. */
+#define FSL_FEATURE_TPM_HAS_PARAM (1)
+/* @brief Has TPM_VERID. */
+#define FSL_FEATURE_TPM_HAS_VERID (1)
+/* @brief Has TPM_GLOBAL. */
+#define FSL_FEATURE_TPM_HAS_GLOBAL (1)
+/* @brief Has TPM_TRIG. */
+#define FSL_FEATURE_TPM_HAS_TRIG (1)
+/* @brief Whether TRIG register has effect. */
+#define FSL_FEATURE_TPM_TRIG_HAS_EFFECTn(x) (0)
+/* @brief Has counter pause on trigger. */
+#define FSL_FEATURE_TPM_HAS_PAUSE_COUNTER_ON_TRIGGER (1)
+/* @brief Has external trigger selection. */
+#define FSL_FEATURE_TPM_HAS_EXTERNAL_TRIGGER_SELECTION (1)
+/* @brief Has TPM_COMBINE register. */
+#define FSL_FEATURE_TPM_HAS_COMBINE (1)
+/* @brief Whether COMBINE register has effect. */
+#define FSL_FEATURE_TPM_COMBINE_HAS_EFFECTn(x) (1)
+/* @brief Has TPM_POL. */
+#define FSL_FEATURE_TPM_HAS_POL (1)
+/* @brief Whether POL register has effect. */
+#define FSL_FEATURE_TPM_POL_HAS_EFFECTn(x) (0)
+/* @brief Has TPM_FILTER register. */
+#define FSL_FEATURE_TPM_HAS_FILTER (1)
+/* @brief Whether FILTER register has effect. */
+#define FSL_FEATURE_TPM_FILTER_HAS_EFFECTn(x) (1)
+/* @brief Has TPM_QDCTRL register. */
+#define FSL_FEATURE_TPM_HAS_QDCTRL (1)
+/* @brief Whether QDCTRL register has effect. */
+#define FSL_FEATURE_TPM_QDCTRL_HAS_EFFECTn(x) (1)
+/* @brief Has pause level select. */
+#define FSL_FEATURE_TPM_HAS_PAUSE_LEVEL_SELECT (1)
+/* @brief Whether 32 bits counter has effect. */
+#define FSL_FEATURE_TPM_HAS_32BIT_COUNTERn(x) (1)
+
+/* TRDC module features */
+
+/* @brief Process master count. */
+#define FSL_FEATURE_TRDC_PROCESSOR_MASTER_COUNT (2)
+/* @brief TRDC instance has PID configuration or not. */
+#define FSL_FEATURE_TRDC_INSTANCE_HAS_PID_CONFIGURATIONn(x) \
+    (((x) == TRDC1) ?                                       \
+         (1) :                                              \
+         (((x) == TRDC2) ?                                  \
+              (0) :                                         \
+              (((x) == TRDC3) ? (0) : (((x) == TRDC_MEDIAMIX) ? (0) : (((x) == TRDC_HSIOMIX) ? (0) : (-1))))))
+/* @brief TRDC domain number (reset value of HWCFG0[NDID]). */
+#define FSL_FEATURE_TRDC_DOMAIN_COUNT (16)
+
+/* TSTMR module features */
+
+/* @brief TSTMR clock frequency is 1MHZ. */
+#define FSL_FEATURE_TSTMR_CLOCK_FREQUENCY_1MHZ (1)
+
+/* USDHC module features */
+
+/* @brief Has external DMA support (VEND_SPEC[EXT_DMA_EN]) */
+#define FSL_FEATURE_USDHC_HAS_EXT_DMA (0)
+/* @brief Has HS400 mode (MIX_CTRL[HS400_MODE]) */
+#define FSL_FEATURE_USDHC_HAS_HS400_MODE (1)
+/* @brief Has SDR50 support (HOST_CTRL_CAP[SDR50_SUPPORT]) */
+#define FSL_FEATURE_USDHC_HAS_SDR50_MODE (1)
+/* @brief Has SDR104 support (HOST_CTRL_CAP[SDR104_SUPPORT]) */
+#define FSL_FEATURE_USDHC_HAS_SDR104_MODE (1)
+/* @brief USDHC has reset control */
+#define FSL_FEATURE_USDHC_HAS_RESET (0)
+/* @brief USDHC has no bitfield WTMK_LVL[WR_BRST_LEN] and WTMK_LVL[RD_BRST_LEN] */
+#define FSL_FEATURE_USDHC_HAS_NO_RW_BURST_LEN (1)
+/* @brief If USDHC instance support 8 bit width */
+#define FSL_FEATURE_USDHC_INSTANCE_SUPPORT_8_BIT_WIDTHn(x) (1)
+/* @brief If USDHC instance support HS400 mode */
+#define FSL_FEATURE_USDHC_INSTANCE_SUPPORT_HS400_MODEn(x) (0)
+/* @brief If USDHC instance support 1v8 signal */
+#define FSL_FEATURE_USDHC_INSTANCE_SUPPORT_1V8_SIGNALn(x) (1)
+/* @brief Has no retuning time counter (HOST_CTRL_CAP[TIME_COUNT_RETURNING]) */
+#define FSL_FEATURE_USDHC_REGISTER_HOST_CTRL_CAP_HAS_NO_RETUNING_TIME_COUNTER (1)
+
+/* WDOG module features */
+
+/* @brief Watchdog is available. */
+#define FSL_FEATURE_WDOG_HAS_WATCHDOG (1)
+/* @brief WDOG_CNT can be 32-bit written. */
+#define FSL_FEATURE_WDOG_HAS_32BIT_ACCESS (1)
+
+#endif /* _MIMX9352_cm33_FEATURES_H_ */

--- a/devices/MIMX9352/device_CMSIS.cmake
+++ b/devices/MIMX9352/device_CMSIS.cmake
@@ -1,0 +1,19 @@
+#Description: device_CMSIS; user_visible: False
+include_guard(GLOBAL)
+message("device_CMSIS component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+if(${MCUX_DEVICE} STREQUAL "MIMX9352")
+    include(CMSIS_Include_core_cm)
+endif()
+
+if(${MCUX_DEVICE} STREQUAL "MIMX9352_ca55")
+    include(CMSIS_Include_core_ca)
+endif()

--- a/devices/MIMX9352/device_MIMX9352_CMSIS_MIMX9352.cmake
+++ b/devices/MIMX9352/device_MIMX9352_CMSIS_MIMX9352.cmake
@@ -1,0 +1,15 @@
+include_guard()
+message("device_MIMX9352_CMSIS component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/system_MIMX9352_cm33.c
+)
+
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(CMSIS_Include_core_cm_MIMX9352)
+

--- a/devices/MIMX9352/device_MIMX9352_startup_MIMX9352.cmake
+++ b/devices/MIMX9352/device_MIMX9352_startup_MIMX9352.cmake
@@ -1,0 +1,8 @@
+include_guard()
+message("device_MIMX9352_startup component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/gcc/startup_MIMX9352_cm33.S
+)
+
+

--- a/devices/MIMX9352/driver_reset.cmake
+++ b/devices/MIMX9352/driver_reset.cmake
@@ -1,0 +1,10 @@
+#Description: Reset Driver; user_visible: False
+include_guard(GLOBAL)
+message("driver_reset component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+)
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)

--- a/devices/MIMX9352/drivers/driver_clock_MIMX9352.cmake
+++ b/devices/MIMX9352/drivers/driver_clock_MIMX9352.cmake
@@ -1,0 +1,15 @@
+include_guard()
+message("driver_clock component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/fsl_clock.c
+)
+
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(driver_common_MIMX9352)
+

--- a/devices/MIMX9352/drivers/driver_edma_soc_MIMX9352.cmake
+++ b/devices/MIMX9352/drivers/driver_edma_soc_MIMX9352.cmake
@@ -1,0 +1,15 @@
+include_guard()
+message("driver_edma_soc component is included.")
+
+target_sources(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/fsl_edma_soc.c
+)
+
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+
+include(driver_common_MIMX9352)
+

--- a/devices/MIMX9352/drivers/driver_iomuxc_MIMX9352.cmake
+++ b/devices/MIMX9352/drivers/driver_iomuxc_MIMX9352.cmake
@@ -1,0 +1,10 @@
+include_guard()
+message("driver_iomuxc component is included.")
+
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+include(driver_common_MIMX9352)
+

--- a/devices/MIMX9352/drivers/driver_memory_MIMX9352.cmake
+++ b/devices/MIMX9352/drivers/driver_memory_MIMX9352.cmake
@@ -1,0 +1,10 @@
+include_guard()
+message("driver_memory component is included.")
+
+
+target_include_directories(${MCUX_SDK_PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/.
+)
+
+include(driver_common_MIMX9352)
+

--- a/devices/MIMX9352/drivers/drv_edma_soc.yml
+++ b/devices/MIMX9352/drivers/drv_edma_soc.yml
@@ -1,0 +1,24 @@
+---
+driver.edma_soc:
+  contents:
+    repo_base_path: devices/MIMX9352/drivers
+    package_base_path: devices/${platform_devices_soc_name}/drivers
+    project_base_path: drivers
+    cc-include:
+    - repo_relative_path: "./"
+    files:
+    - source: fsl_edma_soc.h
+    - source: fsl_edma_soc.c
+  __requires__:
+  - driver.common
+  section-type: component
+  component_info:
+    common:
+      description: EDMA SOC Driver
+      version: 2.0.0
+      type: driver
+      full_name: EDMA SOC Driver
+      change_log: devices/MIMX9352/drivers/ChangeLogKSDK.txt
+      component_bundle: bundle.drivers
+      manifest_name: edma_soc
+      sub: edma_soc

--- a/devices/MIMX9352/drivers/fsl_clock.c
+++ b/devices/MIMX9352/drivers/fsl_clock.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "fsl_clock.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.clock"
+#endif
+
+volatile uint32_t g_clockSourceFreq[kCLOCK_Ext + 1];
+
+uint32_t CLOCK_GetIpFreq(clock_root_t name)
+{
+    clock_name_t clock;
+    uint32_t mux;
+    uint32_t div;
+
+    mux = CLOCK_GetRootClockMux(name);
+    div = CLOCK_GetRootClockDiv(name);
+
+    clock = CLOCK_GetRootClockSource(name, mux);
+    assert(clock <= kCLOCK_Ext);
+
+    return g_clockSourceFreq[clock] / div;
+}

--- a/devices/MIMX9352/drivers/fsl_clock.h
+++ b/devices/MIMX9352/drivers/fsl_clock.h
@@ -1,0 +1,1334 @@
+/*
+ * Copyright 2022 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _FSL_CLOCK_H_
+#define _FSL_CLOCK_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @brief CCM reg macros to map corresponding registers.
+ */
+#define CCM_REG_OFF(root, off) (*((volatile uint32_t *)((uintptr_t)(root) + (off))))
+#define CCM_REG(root)          CCM_REG_OFF(root, 0U)
+
+/* Definition for delay API in clock driver, users can redefine it to the real application. */
+#ifndef SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY
+#define SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY \
+    (2500000000UL) /* When using Overdrive Voltage, the maximum frequency of cm33 is 250 MHz */
+#endif
+
+/*******************************************************************************
+ * PLL Definitions
+ ******************************************************************************/
+
+/*! @brief PLL initialzation data. */
+typedef struct _fracn_pll_init
+{
+    uint32_t rdiv;
+    uint32_t mfi;
+    uint32_t mfn;
+    uint32_t mfd;
+    uint32_t odiv;
+} fracn_pll_init_t;
+
+/*! @brief PLL PFD initialzation data. */
+typedef struct _fracn_pll_pfd_init
+{
+    uint32_t mfi;
+    uint32_t mfn;
+    bool div2_en;
+} fracn_pll_pfd_init_t;
+
+/*!
+ * @brief PLL init.
+ *
+ * @param pll PLL base addr.
+ * @param pll_cfg PLL initailization data.
+ */
+static inline void CLOCK_PllInit(PLL_Type *pll, const fracn_pll_init_t *pll_cfg)
+{
+    /* Bypass PLL */
+    pll->CTRL.SET = PLL_CTRL_CLKMUX_BYPASS_MASK;
+    /* Disable output and PLL */
+    pll->CTRL.CLR = PLL_CTRL_CLKMUX_EN_MASK | PLL_CTRL_POWERUP_MASK;
+    /* Set rdiv, mfi, and odiv */
+    pll->DIV.RW = PLL_DIV_RDIV(pll_cfg->rdiv) | PLL_DIV_MFI(pll_cfg->mfi) | PLL_DIV_ODIV(pll_cfg->odiv);
+    /* Disable spread spectrum modulation */
+    pll->SPREAD_SPECTRUM.CLR = PLL_SPREAD_SPECTRUM_ENABLE_MASK;
+    /* Set mfn and mfd */
+    pll->NUMERATOR.RW   = PLL_NUMERATOR_MFN(pll_cfg->mfn);
+    pll->DENOMINATOR.RW = PLL_DENOMINATOR_MFD(pll_cfg->mfd);
+
+    /* Power up for locking */
+    pll->CTRL.SET = PLL_CTRL_POWERUP_MASK;
+    while (!(pll->PLL_STATUS & PLL_PLL_STATUS_PLL_LOCK_MASK))
+    {
+    }
+
+    /* Enable PLL and clean bypass*/
+    pll->CTRL.SET = PLL_CTRL_CLKMUX_EN_MASK;
+    pll->CTRL.CLR = PLL_CTRL_CLKMUX_BYPASS_MASK;
+    __DSB();
+    __ISB();
+}
+
+/*!
+ * @brief PLL PFD init.
+ *
+ * @param pll PLL base addr.
+ * @param pfd_n The PFD index number.
+ * @param pfd_cfg PLL PFD initailization data.
+ */
+static inline void CLOCK_PllPfdInit(PLL_Type *pll, uint32_t pfd_n, const fracn_pll_pfd_init_t *pfd_cfg)
+{
+    /* Bypass DFS*/
+    pll->NO_OF_DFS[pfd_n].DFS_CTRL.SET = PLL_NO_OF_DFS_BYPASS_EN_MASK;
+    /* Disable output and DFS */
+    pll->NO_OF_DFS[pfd_n].DFS_CTRL.CLR = PLL_NO_OF_DFS_CLKOUT_EN_MASK | PLL_NO_OF_DFS_ENABLE_MASK;
+    /* Set mfi and mfn */
+    pll->NO_OF_DFS[pfd_n].DFS_DIV.RW = PLL_NO_OF_DFS_MFI(pfd_cfg->mfi) | PLL_NO_OF_DFS_MFN(pfd_cfg->mfn);
+    /* Enable output and DFS*/
+    pll->NO_OF_DFS[pfd_n].DFS_CTRL.SET = PLL_NO_OF_DFS_CLKOUT_EN_MASK;
+    /* Enable div2 */
+    if (pfd_cfg->div2_en)
+        pll->NO_OF_DFS[pfd_n].DFS_CTRL.SET = PLL_NO_OF_DFS_CLKOUT_DIVBY2_EN_MASK;
+    /* Enable DFS for locking*/
+    pll->NO_OF_DFS[pfd_n].DFS_CTRL.SET = PLL_NO_OF_DFS_ENABLE_MASK;
+    while (!((pll->DFS_STATUS & PLL_DFS_STATUS_DFS_OK_MASK) & (1 << pfd_n)))
+    {
+    }
+    /* Clean bypass */
+    pll->NO_OF_DFS[pfd_n].DFS_CTRL.CLR = PLL_NO_OF_DFS_BYPASS_EN_MASK;
+    __DSB();
+    __ISB();
+}
+
+/*******************************************************************************
+ * Clock Source Definitions
+ ******************************************************************************/
+
+/*!
+ * @brief Clock name.
+ */
+typedef enum _clock_name
+{
+    kCLOCK_Osc24M          = 0,  /*!< 24MHz Oscillator. */
+    kCLOCK_ArmPll          = 1,  /* ARM PLL */
+    kCLOCK_ArmPllOut       = 2,  /* ARM PLL Out */
+    kCLOCK_DramPll         = 3,  /* DRAM PLL */
+    kCLOCK_DramPllOut      = 4,  /* DRAM PLL Out */
+    kCLOCK_SysPll1         = 5,  /* SYSTEM PLL1 */
+    kCLOCK_SysPll1Pfd0     = 6,  /* SYSTEM PLL1 PFD0 */
+    kCLOCK_SysPll1Pfd0Div2 = 7,  /* SYSTEM PLL1 PFD0 DIV2  */
+    kCLOCK_SysPll1Pfd1     = 8,  /* SYSTEM PLL1 PFD1 */
+    kCLOCK_SysPll1Pfd1Div2 = 9,  /* SYSTEM PLL1 PFD1 DIV2  */
+    kCLOCK_SysPll1Pfd2     = 10, /* SYSTEM PLL1 PFD2 */
+    kCLOCK_SysPll1Pfd2Div2 = 11, /* SYSTEM PLL1 PFD2 DIV2  */
+    kCLOCK_AudioPll1       = 12, /* AUDIO PLL1 */
+    kCLOCK_AudioPll1Out    = 13, /* AUDIO PLL1 Out */
+    kCLOCK_VideoPll1       = 14, /* VEDIO PLL1 */
+    kCLOCK_VideoPll1Out    = 15, /* VEDIO PLL1 Out */
+    kCLOCK_Ext             = 16, /* Ext */
+} clock_name_t;
+
+static const clock_name_t s_clockSourceName[][4] = {
+    /*SRC0,         SRC1,                   SRC2,                   SRC3,            */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Arm A55 Periph */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Arm A55 MTR BUS */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Arm A55 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* M33 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Sentinel */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Bus Wakeup */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Bus Aon */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Wakeup Axi */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Swo Trace */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* M33 Systick */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Flexio1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Flexio2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpit1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpit2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lptmr1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lptmr2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_AudioPll1Out, kCLOCK_Ext},                    /* Tpm1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_AudioPll1Out, kCLOCK_Ext},                    /* Tpm2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_AudioPll1Out, kCLOCK_Ext},                    /* Tpm3 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_AudioPll1Out, kCLOCK_Ext},                    /* Tpm4 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_AudioPll1Out, kCLOCK_Ext},                    /* Tpm5 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_AudioPll1Out, kCLOCK_Ext},                    /* Tpm6 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Flexspi1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Can1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Can2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpuart1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpuart2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpuart3 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpuart4 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpuart5 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpuart6 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpuart7 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpuart8 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpi2c1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpi2c2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpi2c3 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpi2c4 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpi2c5 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpi2c6 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpi2c7 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpi2c8 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpspi1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpspi2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpspi3 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpspi4 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpspi5 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpspi6 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpspi7 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Lpspi8 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* I3c1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* I3c2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Usdhc1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Usdhc2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Usdhc3 */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_Ext},                   /* Sai1 */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_Ext},                   /* Sai2 */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_Ext},                   /* Sai3 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_AudioPll1Out},            /* Ccm Cko1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_VideoPll1Out},            /* Ccm Cko2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_AudioPll1Out},            /* Ccm Cko3 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_VideoPll1Out},            /* Ccm Cko4 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Hsio */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Hsio Usb Test 60M */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Hsio Acscan 80M */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_SysPll1Pfd2},           /* Hsio Acscan 480M */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Nic */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Nic Apb */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Ml Apb */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Ml */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Media Axi */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Media Apb */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_SysPll1Pfd0},           /* Media Ldb */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_SysPll1Pfd0},           /* Media Disp Pix */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_SysPll1Pfd0},           /* Cam Pix */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_SysPll1Pfd0},           /* Mipi Test Byte */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_SysPll1Pfd0},           /* Mipi Phy Cfg */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0, kCLOCK_SysPll1Pfd1, kCLOCK_SysPll1Pfd2},             /* Dram Alt */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_SysPll1Pfd2Div2}, /* Dram Apb */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Adc */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_Ext},                   /* Pdm */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Tstmr1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Tstmr2 */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_Ext},                   /* Mqs1 */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_Ext},                   /* Mqs2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_SysPll1Pfd2Div2}, /* Audio XCVR */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_Ext},                   /* Spdif */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_SysPll1Pfd2Div2}, /* Enet */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Enet Timer1 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Enet Timer2 */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_SysPll1Pfd2Div2}, /* Enet Ref */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Enet Ref Phy */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* I3c1 Slow */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* I3c2 Slow */
+    {kCLOCK_Osc24M, kCLOCK_SysPll1Pfd0Div2, kCLOCK_SysPll1Pfd1Div2, kCLOCK_VideoPll1Out},    /* Usb Phy Burunin */
+    {kCLOCK_Osc24M, kCLOCK_AudioPll1Out, kCLOCK_VideoPll1Out, kCLOCK_SysPll1Pfd2}            /* Pal Came Scan */
+};
+
+/*******************************************************************************
+ * Clock Root Definitions
+ ******************************************************************************/
+
+/*! @brief Clock root configuration */
+typedef struct _clock_root_config_t
+{
+    bool clockOff;
+    uint8_t mux; /*!< See #clock_root_mux_source_t for details. */
+    uint8_t div; /*!< it's the actual divider */
+} clock_root_config_t;
+
+/*!
+ * @brief Root clock index
+ */
+typedef enum _clock_root
+{
+    kCLOCK_Root_A55Periph      = 0,  /*!< CLOCK Root Arm A55 Periph. */
+    kCLOCK_Root_A55MtrBus      = 1,  /*!< CLOCK Root Arm A55 MTR BUS. */
+    kCLOCK_Root_A55            = 2,  /*!< CLOCK Root Arm A55. */
+    kCLOCK_Root_M33            = 3,  /*!< CLOCK Root M33. */
+    kCLOCK_Root_Sentinel       = 4,  /*!< CLOCK Root Sentinel. */
+    kCLOCK_Root_BusWakeup      = 5,  /*!< CLOCK Root Bus Wakeup. */
+    kCLOCK_Root_BusAon         = 6,  /*!< CLOCK Root Bus Aon. */
+    kCLOCK_Root_WakeupAxi      = 7,  /*!< CLOCK Root Wakeup Axi. */
+    kCLOCK_Root_SwoTrace       = 8,  /*!< CLOCK Root Swo Trace. */
+    kCLOCK_Root_M33Systick     = 9,  /*!< CLOCK Root M33 Systick. */
+    kCLOCK_Root_Flexio1        = 10, /*!< CLOCK Root Flexio1. */
+    kCLOCK_Root_Flexio2        = 11, /*!< CLOCK Root Flexio2. */
+    kCLOCK_Root_Lpit1          = 12, /*!< CLOCK Root Lpit1. */
+    kCLOCK_Root_Lpit2          = 13, /*!< CLOCK Root Lpit2. */
+    kCLOCK_Root_Lptmr1         = 14, /*!< CLOCK Root Lptmr1. */
+    kCLOCK_Root_Lptmr2         = 15, /*!< CLOCK Root Lptmr2. */
+    kCLOCK_Root_Tpm1           = 16, /*!< CLOCK Root Tpm1. */
+    kCLOCK_Root_Tpm2           = 17, /*!< CLOCK Root Tpm2. */
+    kCLOCK_Root_Tpm3           = 18, /*!< CLOCK Root Tpm3. */
+    kCLOCK_Root_Tpm4           = 19, /*!< CLOCK Root Tpm4. */
+    kCLOCK_Root_Tpm5           = 20, /*!< CLOCK Root Tpm5. */
+    kCLOCK_Root_Tpm6           = 21, /*!< CLOCK Root Tpm6. */
+    kCLOCK_Root_Flexspi1       = 22, /*!< CLOCK Root Flexspi1. */
+    kCLOCK_Root_Can1           = 23, /*!< CLOCK Root Can1. */
+    kCLOCK_Root_Can2           = 24, /*!< CLOCK Root Can2. */
+    kCLOCK_Root_Lpuart1        = 25, /*!< CLOCK Root Lpuart1. */
+    kCLOCK_Root_Lpuart2        = 26, /*!< CLOCK Root Lpuart2. */
+    kCLOCK_Root_Lpuart3        = 27, /*!< CLOCK Root Lpuart3. */
+    kCLOCK_Root_Lpuart4        = 28, /*!< CLOCK Root Lpuart4. */
+    kCLOCK_Root_Lpuart5        = 29, /*!< CLOCK Root Lpuart5. */
+    kCLOCK_Root_Lpuart6        = 30, /*!< CLOCK Root Lpuart6. */
+    kCLOCK_Root_Lpuart7        = 31, /*!< CLOCK Root Lpuart7. */
+    kCLOCK_Root_Lpuart8        = 32, /*!< CLOCK Root Lpuart8. */
+    kCLOCK_Root_Lpi2c1         = 33, /*!< CLOCK Root Lpi2c1. */
+    kCLOCK_Root_Lpi2c2         = 34, /*!< CLOCK Root Lpi2c2. */
+    kCLOCK_Root_Lpi2c3         = 35, /*!< CLOCK Root Lpi2c3. */
+    kCLOCK_Root_Lpi2c4         = 36, /*!< CLOCK Root Lpi2c4. */
+    kCLOCK_Root_Lpi2c5         = 37, /*!< CLOCK Root Lpi2c5. */
+    kCLOCK_Root_Lpi2c6         = 38, /*!< CLOCK Root Lpi2c6. */
+    kCLOCK_Root_Lpi2c7         = 39, /*!< CLOCK Root Lpi2c7. */
+    kCLOCK_Root_Lpi2c8         = 40, /*!< CLOCK Root Lpi2c8. */
+    kCLOCK_Root_Lpspi1         = 41, /*!< CLOCK Root Lpspi1. */
+    kCLOCK_Root_Lpspi2         = 42, /*!< CLOCK Root Lpspi2. */
+    kCLOCK_Root_Lpspi3         = 43, /*!< CLOCK Root Lpspi3. */
+    kCLOCK_Root_Lpspi4         = 44, /*!< CLOCK Root Lpspi4. */
+    kCLOCK_Root_Lpspi5         = 45, /*!< CLOCK Root Lpspi5. */
+    kCLOCK_Root_Lpspi6         = 46, /*!< CLOCK Root Lpspi6. */
+    kCLOCK_Root_Lpspi7         = 47, /*!< CLOCK Root Lpspi7. */
+    kCLOCK_Root_Lpspi8         = 48, /*!< CLOCK Root Lpspi8. */
+    kCLOCK_Root_I3c1           = 49, /*!< CLOCK Root I3c1. */
+    kCLOCK_Root_I3c2           = 50, /*!< CLOCK Root I3c2. */
+    kCLOCK_Root_Usdhc1         = 51, /*!< CLOCK Root Usdhc1. */
+    kCLOCK_Root_Usdhc2         = 52, /*!< CLOCK Root Usdhc2. */
+    kCLOCK_Root_Usdhc3         = 53, /*!< CLOCK Root Usdhc3. */
+    kCLOCK_Root_Sai1           = 54, /*!< CLOCK Root Sai1. */
+    kCLOCK_Root_Sai2           = 55, /*!< CLOCK Root Sai2. */
+    kCLOCK_Root_Sai3           = 56, /*!< CLOCK Root Sai3. */
+    kCLOCK_Root_CcmCko1        = 57, /*!< CLOCK Root Ccm Cko1. */
+    kCLOCK_Root_CcmCko2        = 58, /*!< CLOCK Root Ccm Cko2. */
+    kCLOCK_Root_CcmCko3        = 59, /*!< CLOCK Root Ccm Cko3. */
+    kCLOCK_Root_CcmCko4        = 60, /*!< CLOCK Root Ccm Cko4. */
+    kCLOCK_Root_Hsio           = 61, /*!< CLOCK Root Hsio. */
+    kCLOCK_Root_HsioUsbTest60M = 62, /*!< CLOCK Root Hsio Usb Test 60M. */
+    kCLOCK_Root_HsioAcscan80M  = 63, /*!< CLOCK Root Hsio Acscan 80M. */
+    kCLOCK_Root_HsioAcscan480M = 64, /*!< CLOCK Root Hsio Acscan 480M. */
+    kCLOCK_Root_Nic            = 65, /*!< CLOCK Root Nic. */
+    kCLOCK_Root_NicApb         = 66, /*!< CLOCK Root Nic Apb. */
+    kCLOCK_Root_MlApb          = 67, /*!< CLOCK Root Ml Apb. */
+    kCLOCK_Root_Ml             = 68, /*!< CLOCK Root Ml. */
+    kCLOCK_Root_MediaAxi       = 69, /*!< CLOCK Root Media Axi. */
+    kCLOCK_Root_MediaApb       = 70, /*!< CLOCK Root Media Apb. */
+    kCLOCK_Root_MediaLdb       = 71, /*!< CLOCK Root Media Ldb. */
+    kCLOCK_Root_MediaDispPix   = 72, /*!< CLOCK Root Media Disp Pix. */
+    kCLOCK_Root_CamPix         = 73, /*!< CLOCK Root Cam Pix. */
+    kCLOCK_Root_MipiTestByte   = 74, /*!< CLOCK Root Mipi Test Byte. */
+    kCLOCK_Root_MipiPhyCfg     = 75, /*!< CLOCK Root Mipi Phy Cfg. */
+    kCLOCK_Root_DramAlt        = 76, /*!< CLOCK Root Dram Alt. */
+    kCLOCK_Root_DramApb        = 77, /*!< CLOCK Root Dram Apb. */
+    kCLOCK_Root_Adc            = 78, /*!< CLOCK Root Adc. */
+    kCLOCK_Root_Pdm            = 79, /*!< CLOCK Root Pdm. */
+    kCLOCK_Root_Tstmr1         = 80, /*!< CLOCK Root Tstmr1. */
+    kCLOCK_Root_Tstmr2         = 81, /*!< CLOCK Root Tstmr2. */
+    kCLOCK_Root_Mqs1           = 82, /*!< CLOCK Root MQS1. */
+    kCLOCK_Root_Mqs2           = 83, /*!< CLOCK Root MQS2. */
+    kCLOCK_Root_AudioXCVR      = 84, /*!< CLOCK Root Audio XCVR. */
+    kCLOCK_Root_Spdif          = 85, /*!< CLOCK Root Spdif. */
+    kCLOCK_Root_Enet           = 86, /*!< CLOCK Root Enet. */
+    kCLOCK_Root_EnetTimer1     = 87, /*!< CLOCK Root Enet Timer1. */
+    kCLOCK_Root_EnetTimer2     = 88, /*!< CLOCK Root Enet Timer2. */
+    kCLOCK_Root_EnetRef        = 89, /*!< CLOCK Root Enet Ref. */
+    kCLOCK_Root_EnetRefPhy     = 90, /*!< CLOCK Root Enet Ref Phy. */
+    kCLOCK_Root_I3c1Slow       = 91, /*!< CLOCK Root I3c1Slow. */
+    kCLOCK_Root_I3c2Slow       = 92, /*!< CLOCK Root I3c2Slow. */
+    kCLOCK_Root_UsbPhyBurunin  = 93, /*!< CLOCK Root Usb Phy Burunin. */
+    kCLOCK_Root_PalCameScan    = 94, /*!< CLOCK Root Pal Came Scan. */
+} clock_root_t;
+
+/*!
+ * @brief The enumerator of clock roots' clock source mux value.
+ */
+typedef enum _clock_root_mux_source
+{
+    /* ARM A55 Periph */
+    kCLOCK_A55PERIPH_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_A55PERIPH_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_A55PERIPH_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_A55PERIPH_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* ARM A55 MTR BUS */
+    kCLOCK_A55MTRBUS_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_A55MTRBUS_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_A55MTRBUS_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_A55MTRBUS_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* ARM A55 */
+    kCLOCK_A55_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_A55_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_A55_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_A55_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* M33 */
+    kCLOCK_M33_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_M33_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_M33_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_M33_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Sentinel */
+    kCLOCK_SENTINEL_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_SENTINEL_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_SENTINEL_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_SENTINEL_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Bus Wakeup */
+    kCLOCK_BUSWAKEUP_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_BUSWAKEUP_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_BUSWAKEUP_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_BUSWAKEUP_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Bus Aon */
+    kCLOCK_BUSAON_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_BUSAON_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_BUSAON_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_BUSAON_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Wakeup Axi */
+    kCLOCK_WAKEUPAXI_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_WAKEUPAXI_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_WAKEUPAXI_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_WAKEUPAXI_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* Swo Trace */
+    kCLOCK_SWOTRACE_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_SWOTRACE_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_SWOTRACE_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_SWOTRACE_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* M33 Systick */
+    kCLOCK_M33SYSTICK_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_M33SYSTICK_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_M33SYSTICK_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_M33SYSTICK_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Flexio1 */
+    kCLOCK_FLEXIO1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_FLEXIO1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_FLEXIO1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_FLEXIO1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Flexio2 */
+    kCLOCK_FLEXIO2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_FLEXIO2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_FLEXIO2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_FLEXIO2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpit1 */
+    kCLOCK_LPIT1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPIT1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPIT1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPIT1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpit2 */
+    kCLOCK_LPIT2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPIT2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPIT2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPIT2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lptmr1 */
+    kCLOCK_LPTMR1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPTMR1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPTMR1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPTMR1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lptmr2 */
+    kCLOCK_LPTMR2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPTMR2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPTMR2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPTMR2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Tpm1 */
+    kCLOCK_TPM1_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_TPM1_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_TPM1_ClockRoot_MuxAudioPll1Out = 2U,
+    kCLOCK_TPM1_ClockRoot_MuxExt          = 3U,
+
+    /* Tpm2 */
+    kCLOCK_TPM2_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_TPM2_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_TPM2_ClockRoot_MuxAudioPll1Out = 2U,
+    kCLOCK_TPM2_ClockRoot_MuxExt          = 3U,
+
+    /* Tpm3 */
+    kCLOCK_TPM3_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_TPM3_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_TPM3_ClockRoot_MuxAudioPll1Out = 2U,
+    kCLOCK_TPM3_ClockRoot_MuxExt          = 3U,
+
+    /* Tpm4 */
+    kCLOCK_TPM4_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_TPM4_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_TPM4_ClockRoot_MuxAudioPll1Out = 2U,
+    kCLOCK_TPM4_ClockRoot_MuxExt          = 3U,
+
+    /* Tpm5 */
+    kCLOCK_TPM5_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_TPM5_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_TPM5_ClockRoot_MuxAudioPll1Out = 2U,
+    kCLOCK_TPM5_ClockRoot_MuxExt          = 3U,
+
+    /* Tpm6 */
+    kCLOCK_TPM6_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_TPM6_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_TPM6_ClockRoot_MuxAudioPll1Out = 2U,
+    kCLOCK_TPM6_ClockRoot_MuxExt          = 3U,
+
+    /* Flexspi1 */
+    kCLOCK_FLEXSPI1_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_FLEXSPI1_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_FLEXSPI1_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_FLEXSPI1_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* Can1 */
+    kCLOCK_CAN1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_CAN1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_CAN1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_CAN1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Can2 */
+    kCLOCK_CAN2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_CAN2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_CAN2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_CAN2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpuart1 */
+    kCLOCK_LPUART1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPUART1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPUART1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPUART1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpuart2 */
+    kCLOCK_LPUART2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPUART2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPUART2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPUART2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpuart3 */
+    kCLOCK_LPUART3_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPUART3_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPUART3_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPUART3_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpuart4 */
+    kCLOCK_LPUART4_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPUART4_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPUART4_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPUART4_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpuart5 */
+    kCLOCK_LPUART5_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPUART5_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPUART5_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPUART5_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpuart6 */
+    kCLOCK_LPUART6_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPUART6_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPUART6_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPUART6_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpuart7 */
+    kCLOCK_LPUART7_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPUART7_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPUART7_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPUART7_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpuart8 */
+    kCLOCK_LPUART8_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPUART8_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPUART8_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPUART8_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpi2c1 */
+    kCLOCK_LPI2C1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPI2C1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPI2C1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPI2C1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpi2c2 */
+    kCLOCK_LPI2C2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPI2C2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPI2C2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPI2C2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpi2c3 */
+    kCLOCK_LPI2C3_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPI2C3_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPI2C3_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPI2C3_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpi2c4 */
+    kCLOCK_LPI2C4_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPI2C4_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPI2C4_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPI2C4_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpi2c5 */
+    kCLOCK_LPI2C5_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPI2C5_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPI2C5_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPI2C5_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpi2c6 */
+    kCLOCK_LPI2C6_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPI2C6_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPI2C6_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPI2C6_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpi2c7 */
+    kCLOCK_LPI2C7_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPI2C7_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPI2C7_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPI2C7_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpi2c8 */
+    kCLOCK_LPI2C8_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPI2C8_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPI2C8_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPI2C8_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpspi1 */
+    kCLOCK_LPSPI1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPSPI1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPSPI1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPSPI1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpspi2 */
+    kCLOCK_LPSPI2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPSPI2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPSPI2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPSPI2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpspi3 */
+    kCLOCK_LPSPI3_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPSPI3_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPSPI3_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPSPI3_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpspi4 */
+    kCLOCK_LPSPI4_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPSPI4_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPSPI4_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPSPI4_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpispi5 */
+    kCLOCK_LPSPI5_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPSPI5_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPSPI5_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPSPI5_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpspi6 */
+    kCLOCK_LPSPI6_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPSPI6_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPSPI6_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPSPI6_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpspi7 */
+    kCLOCK_LPSPI7_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPSPI7_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPSPI7_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPSPI7_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Lpspi8 */
+    kCLOCK_LPSPI8_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_LPSPI8_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_LPSPI8_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_LPSPI8_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* I3c1 */
+    kCLOCK_I3C1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_I3C1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_I3C1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_I3C1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* I3c2 */
+    kCLOCK_I3C2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_I3C2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_I3C2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_I3C2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Usdhc1 */
+    kCLOCK_Usdhc1_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_Usdhc1_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_Usdhc1_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_Usdhc1_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* Usdhc2 */
+    kCLOCK_Usdhc2_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_Usdhc2_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_Usdhc2_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_Usdhc2_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* Usdhc3 */
+    kCLOCK_Usdhc3_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_Usdhc3_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_Usdhc3_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_Usdhc3_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* Sai1 */
+    kCLOCK_SAI1_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_SAI1_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_SAI1_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_SAI1_ClockRoot_MuxExt          = 3U,
+
+    /* Sai2 */
+    kCLOCK_SAI2_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_SAI2_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_SAI2_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_SAI2_ClockRoot_MuxExt          = 3U,
+
+    /* Sai3 */
+    kCLOCK_SAI3_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_SAI3_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_SAI3_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_SAI3_ClockRoot_MuxExt          = 3U,
+
+    /* Ccm Cko1 */
+    kCLOCK_CCMCKO1_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_CCMCKO1_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_CCMCKO1_ClockRoot_MuxSysPll1Pfd1  = 2U,
+    kCLOCK_CCMCKO1_ClockRoot_MuxAudioPll1Out = 3U,
+
+    /* Ccm Cko2 */
+    kCLOCK_CCMCKO2_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_CCMCKO2_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_CCMCKO2_ClockRoot_MuxSysPll1Pfd1  = 2U,
+    kCLOCK_CCMCKO2_ClockRoot_MuxVideoPll1Out = 3U,
+
+    /* Ccm Cko3 */
+    kCLOCK_CCMCKO3_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_CCMCKO3_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_CCMCKO3_ClockRoot_MuxSysPll1Pfd1  = 2U,
+    kCLOCK_CCMCKO3_ClockRoot_MuxAudioPll1Out = 3U,
+
+    /* Ccm Cko4 */
+    kCLOCK_CCMCKO4_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_CCMCKO4_ClockRoot_MuxSysPll1Pfd0  = 1U,
+    kCLOCK_CCMCKO4_ClockRoot_MuxSysPll1Pfd1  = 2U,
+    kCLOCK_CCMCKO4_ClockRoot_MuxVideoPll1Out = 3U,
+
+    /* Hsio */
+    kCLOCK_HSIO_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_HSIO_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_HSIO_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_HSIO_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Hsio Usb Test 60M */
+    kCLOCK_HSIOUSBTEST60M_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_HSIOUSBTEST60M_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_HSIOUSBTEST60M_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_HSIOUSBTEST60M_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Hsio Acscan 80M */
+    kCLOCK_HSIOACSCAN80M_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_HSIOACSCAN80M_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_HSIOACSCAN80M_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_HSIOACSCAN80M_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Hsio Acscan 480M */
+    kCLOCK_HSIOACSCAN480M_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_HSIOACSCAN480M_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_HSIOACSCAN480M_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_HSIOACSCAN480M_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Nic */
+    kCLOCK_NIC_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_NIC_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_NIC_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_NIC_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* Nic Apb */
+    kCLOCK_NICAPB_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_NICAPB_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_NICAPB_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_NICAPB_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Ml Apb */
+    kCLOCK_MLAPB_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_MLAPB_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_MLAPB_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_MLAPB_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Ml */
+    kCLOCK_ML_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_ML_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_ML_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_ML_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* Media Axi */
+    kCLOCK_MEDIAAXI_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_MEDIAAXI_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_MEDIAAXI_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_MEDIAAXI_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* Media Apb */
+    kCLOCK_MEDIAAPB_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_MEDIAAPB_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_MEDIAAPB_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_MEDIAAPB_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Media Ldb */
+    kCLOCK_MEDIALDB_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_MEDIALDB_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_MEDIALDB_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_MEDIALDB_ClockRoot_MuxSysPll1Pfd0  = 3U,
+
+    /* Media Disp Pix */
+    kCLOCK_MEDIADISPPIX_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_MEDIADISPPIX_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_MEDIADISPPIX_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_MEDIADISPPIX_ClockRoot_MuxSysPll1Pfd0  = 3U,
+
+    /* Cam Pix */
+    kCLOCK_CAMPIX_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_CAMPIX_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_CAMPIX_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_CAMPIX_ClockRoot_MuxSysPll1Pfd0  = 3U,
+
+    /* Mipi Test Byte */
+    kCLOCK_MIPITESTBYTE_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_MIPITESTBYTE_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_MIPITESTBYTE_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_MIPITESTBYTE_ClockRoot_MuxSysPll1Pfd0  = 3U,
+
+    /* Mipi Phy Cfg */
+    kCLOCK_MIPIPHYCFG_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_MIPIPHYCFG_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_MIPIPHYCFG_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_MIPIPHYCFG_ClockRoot_MuxSysPll1Pfd0  = 3U,
+
+    /* Dram Alt */
+    kCLOCK_DRAMALT_ClockRoot_MuxOsc24M      = 0U,
+    kCLOCK_DRAMALT_ClockRoot_MuxSysPll1Pfd0 = 1U,
+    kCLOCK_DRAMALT_ClockRoot_MuxSysPll1Pfd1 = 2U,
+    kCLOCK_DRAMALT_ClockRoot_MuxSysPll1Pfd2 = 3U,
+
+    /* Dram Apb */
+    kCLOCK_DRAMAPB_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_DRAMAPB_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_DRAMAPB_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_DRAMAPB_ClockRoot_MuxSysPll1Pfd2Div2 = 3U,
+
+    /* Adc */
+    kCLOCK_ADC_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_ADC_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_ADC_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_ADC_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Pdm */
+    kCLOCK_PDM_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_PDM_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_PDM_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_PDM_ClockRoot_MuxExt          = 3U,
+
+    /* Tstmr1 */
+    kCLOCK_TSTMR1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_TSTMR1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_TSTMR1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_TSTMR1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Tstmr2 */
+    kCLOCK_TSTMR2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_TSTMR2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_TSTMR2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_TSTMR2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* MQS1 */
+    kCLOCK_MQS1_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_MQS1_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_MQS1_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_MQS1_ClockRoot_MuxExt          = 3U,
+
+    /* MQS2 */
+    kCLOCK_MQS2_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_MQS2_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_MQS2_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_MQS2_ClockRoot_MuxExt          = 3U,
+
+    /* Audio XCVR */
+    kCLOCK_AUDIOXCVR_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_AUDIOXCVR_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_AUDIOXCVR_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_AUDIOXCVR_ClockRoot_MuxSysPll1Pfd2Div2 = 3U,
+
+    /* Spdif */
+    kCLOCK_SPDIF_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_SPDIF_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_SPDIF_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_SPDIF_ClockRoot_MuxExt          = 3U,
+
+    /* Enet */
+    kCLOCK_ENET_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_ENET_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_ENET_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_ENET_ClockRoot_MuxSysPll1Pfd2Div2 = 3U,
+
+    /* Enet Timer1 */
+    kCLOCK_ENETTSTMR1_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_ENETTSTMR1_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_ENETTSTMR1_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_ENETTSTMR1_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Enet Timer2 */
+    kCLOCK_ENETTSTMR2_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_ENETTSTMR2_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_ENETTSTMR2_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_ENETTSTMR2_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Enet Ref */
+    kCLOCK_ENETREF_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_ENETREF_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_ENETREF_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_ENETREF_ClockRoot_MuxSysPll1Pfd2Div2 = 3U,
+
+    /* Enet Ref Phy */
+    kCLOCK_ENETREFPHY_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_ENETREFPHY_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_ENETREFPHY_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_ENETREFPHY_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* I3c1 Slow */
+    kCLOCK_I3C1SLOW_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_I3C1SLOW_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_I3C1SLOW_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_I3C1SLOW_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* I3c2 Slow */
+    kCLOCK_I3C2SLOW_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_I3C2SLOW_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_I3C2SLOW_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_I3C2SLOW_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Usb Phy Burunin */
+    kCLOCK_USBPHYBURUNIN_ClockRoot_MuxOsc24M          = 0U,
+    kCLOCK_USBPHYBURUNIN_ClockRoot_MuxSysPll1Pfd0Div2 = 1U,
+    kCLOCK_USBPHYBURUNIN_ClockRoot_MuxSysPll1Pfd1Div2 = 2U,
+    kCLOCK_USBPHYBURUNIN_ClockRoot_MuxVideoPll1Out    = 3U,
+
+    /* Pal Came Scan */
+    kCLOCK_PALCAMESCAN_ClockRoot_MuxOsc24M       = 0U,
+    kCLOCK_PALCAMESCAN_ClockRoot_MuxAudioPll1Out = 1U,
+    kCLOCK_PALCAMESCAN_ClockRoot_MuxVideoPll1Out = 2U,
+    kCLOCK_PALCAMESCAN_ClockRoot_MuxSysPll1Pfd2  = 3U,
+} clock_root_mux_source_t;
+
+/*******************************************************************************
+ * Clock Gate Definitions
+ ******************************************************************************/
+
+/*! @brief Clock gate value */
+typedef enum _clock_gate_value
+{
+    kCLOCK_Off = (int)~CCM_LPCG_DIRECT_ON_MASK, /*!< Clock is off. */
+    kCLOCK_On  = CCM_LPCG_DIRECT_ON_MASK,       /*!< Clock is on*/
+} clock_gate_value_t;
+
+/*!
+ * @brief Clock LPCG index (Clock Gating Channel)
+ */
+typedef enum _clock_lpcg
+{
+    kCLOCK_A55            = 0,
+    kCLOCK_Cm33           = 1,
+    kCLOCK_Arm_Trout      = 2,
+    kCLOCK_Sentinel       = 3,
+    kCLOCK_Sim_Wakeup     = 4,
+    kCLOCK_Sim_Aon        = 5,
+    kCLOCK_Sim_Mega       = 6,
+    kCLOCK_Anadig         = 7,
+    kCLOCK_Src            = 8,
+    kCLOCK_Ccm            = 9,
+    kCLOCK_Gpc            = 10,
+    kCLOCK_Adc1           = 11,
+    kCLOCK_Wdog1          = 12,
+    kCLOCK_Wdog2          = 13,
+    kCLOCK_Wdog3          = 14,
+    kCLOCK_Wdog4          = 15,
+    kCLOCK_Wdog5          = 16,
+    kCLOCK_Sema1          = 17,
+    kCLOCK_Sema2          = 18,
+    kCLOCK_Mu_A           = 19,
+    kCLOCK_Mu_B           = 20,
+    kCLOCK_Edma1          = 21,
+    kCLOCK_Edma2          = 22,
+    kCLOCK_Romcp_A55      = 23,
+    kCLOCK_Romcp_M33      = 24,
+    kCLOCK_Flexspi1       = 25,
+    kCLOCK_Aon_Trdc       = 26,
+    kCLOCK_Wkup_Trdc      = 27,
+    kCLOCK_Ocotp          = 28,
+    kCLOCK_Bbsm_Hp        = 29,
+    kCLOCK_Bbsm           = 30,
+    kCLOCK_Cstrace        = 31,
+    kCLOCK_Csswo          = 32,
+    kCLOCK_Iomuxc         = 33,
+    kCLOCK_Gpio1          = 34,
+    kCLOCK_Gpio2          = 35,
+    kCLOCK_Gpio3          = 36,
+    kCLOCK_Gpio4          = 37,
+    kCLOCK_Flexio1        = 38,
+    kCLOCK_Flexio2        = 39,
+    kCLOCK_Lpit1          = 40,
+    kCLOCK_Lpit2          = 41,
+    kCLOCK_Lptmr1         = 42,
+    kCLOCK_Lptmr2         = 43,
+    kCLOCK_Tpm1           = 44,
+    kCLOCK_Tpm2           = 45,
+    kCLOCK_Tpm3           = 46,
+    kCLOCK_Tpm4           = 47,
+    kCLOCK_Tpm5           = 48,
+    kCLOCK_Tpm6           = 49,
+    kCLOCK_Can1           = 50,
+    kCLOCK_Can2           = 51,
+    kCLOCK_Lpuart1        = 52,
+    kCLOCK_Lpuart2        = 53,
+    kCLOCK_Lpuart3        = 54,
+    kCLOCK_Lpuart4        = 55,
+    kCLOCK_Lpuart5        = 56,
+    kCLOCK_Lpuart6        = 57,
+    kCLOCK_Lpuart7        = 58,
+    kCLOCK_Lpuart8        = 59,
+    kCLOCK_Lpi2c1         = 60,
+    kCLOCK_Lpi2c2         = 61,
+    kCLOCK_Lpi2c3         = 62,
+    kCLOCK_Lpi2c4         = 63,
+    kCLOCK_Lpi2c5         = 64,
+    kCLOCK_Lpi2c6         = 65,
+    kCLOCK_Lpi2c7         = 66,
+    kCLOCK_Lpi2c8         = 67,
+    kCLOCK_Lpspi1         = 68,
+    kCLOCK_Lpspi2         = 69,
+    kCLOCK_Lpspi3         = 70,
+    kCLOCK_Lpspi4         = 71,
+    kCLOCK_Lpspi5         = 72,
+    kCLOCK_Lpspi6         = 73,
+    kCLOCK_Lpspi7         = 74,
+    kCLOCK_Lpspi8         = 75,
+    kCLOCK_I3c1           = 76,
+    kCLOCK_I3c2           = 77,
+    kCLOCK_Usdhc1         = 78,
+    kCLOCK_Usdhc2         = 79,
+    kCLOCK_Usdhc3         = 80,
+    kCLOCK_Sai1           = 81,
+    kCLOCK_Sai2           = 82,
+    kCLOCK_Sai3           = 83,
+    kCLOCK_Ssi_W2ao       = 84,
+    kCLOCK_Ssi_Ao2w       = 85,
+    kCLOCK_Mipi_Csi       = 86,
+    kCLOCK_Mipi_Dsi       = 87,
+    kCLOCK_Lvds           = 88,
+    kCLOCK_Lcdif          = 89,
+    kCLOCK_Pxp            = 90,
+    kCLOCK_Isi            = 91,
+    kCLOCK_Nic_Media      = 92,
+    kCLOCK_Ddr_Dfi        = 93,
+    kCLOCK_Ddr_Ctl        = 94,
+    kCLOCK_Ddr_Dfi_Ctl    = 95,
+    kCLOCK_Ddr_Ssi        = 96,
+    kCLOCK_Ddr_Bypass     = 97,
+    kCLOCK_Ddr_Apb        = 98,
+    kCLOCK_Ddr_Drampll    = 99,
+    kCLOCK_Ddr_Clk_Ctl    = 100,
+    kCLOCK_Nic_Central    = 101,
+    kCLOCK_Gic600         = 102,
+    kCLOCK_Nic_Apb        = 103,
+    kCLOCK_Usb_Controller = 104,
+    kCLOCK_Usb_Test_60m   = 105,
+    kCLOCK_Hsio_Trout_24m = 106,
+    kCLOCK_Pdm            = 107,
+    kCLOCK_Mqs1           = 108,
+    kCLOCK_Mqs2           = 109,
+    kCLOCK_Aud_Xcvr       = 110,
+    kCLOCK_Nicmix_Mecc    = 111,
+    kCLOCK_Spdif          = 112,
+    kCLOCK_Ssi_Ml2nic     = 113,
+    kCLOCK_Ssi_Med2nic    = 114,
+    kCLOCK_Ssi_Hsio2nic   = 115,
+    kCLOCK_Ssi_W2nic      = 116,
+    kCLOCK_Ssi_Nic2w      = 117,
+    kCLOCK_Ssi_Nic2ddr    = 118,
+    kCLOCK_Hsio_32k       = 119,
+    kCLOCK_Enet1          = 120,
+    kCLOCK_Enet_Qos       = 121,
+    kCLOCK_Sys_Cnt        = 122,
+    kCLOCK_Tstmr1         = 123,
+    kCLOCK_Tstmr2         = 124,
+    kCLOCK_Tmc            = 125,
+    kCLOCK_Pmro           = 126,
+    kCLOCK_IpInvalid,
+} clock_lpcg_t;
+
+#define clock_ip_name_t clock_lpcg_t
+
+/*! @brief Clock ip name array for EDMA. */
+#define EDMA_CLOCKS                \
+    {                              \
+        kCLOCK_Edma1, kCLOCK_Edma2 \
+    }
+
+/*
+ * ! @brief Clock ip name array for MU.
+ * clock of MU1_MUA, MU2_MUA is enabled by same LPCG42(Gate signal is clk_enable_mu_a)
+ */
+#define MU_CLOCKS                \
+    {                            \
+        kCLOCK_Mu_A, kCLOCK_Mu_A \
+    }
+
+/*! @brief Clock ip name array for LPI2C. */
+#define LPI2C_CLOCKS                                                                                                \
+    {                                                                                                               \
+        kCLOCK_IpInvalid, kCLOCK_Lpi2c1, kCLOCK_Lpi2c2, kCLOCK_Lpi2c3, kCLOCK_Lpi2c4, kCLOCK_Lpi2c5, kCLOCK_Lpi2c6, \
+            kCLOCK_Lpi2c7, kCLOCK_Lpi2c8                                                                            \
+    }
+
+/*! @brief Clock ip name array for LPIT. */
+#define LPIT_CLOCKS                                  \
+    {                                                \
+        kCLOCK_IpInvalid, kCLOCK_Lpit1, kCLOCK_Lpit2 \
+    }
+
+/*! @brief Clock ip name array for LPSPI. */
+#define LPSPI_CLOCKS                                                                                                \
+    {                                                                                                               \
+        kCLOCK_IpInvalid, kCLOCK_Lpspi1, kCLOCK_Lpspi2, kCLOCK_Lpspi3, kCLOCK_Lpspi4, kCLOCK_Lpspi5, kCLOCK_Lpspi6, \
+            kCLOCK_Lpspi7, kCLOCK_Lpspi8                                                                            \
+    }
+
+/*! @brief Clock ip name array for TPM. */
+#define TPM_CLOCKS                                                                    \
+    {                                                                                 \
+        kCLOCK_Tpm1, kCLOCK_Tpm2, kCLOCK_Tpm3, kCLOCK_Tpm4, kCLOCK_Tpm5, kCLOCK_Tpm6, \
+    }
+
+/*! @brief Clock ip name array for FLEXCAN. */
+#define FLEXCAN_CLOCKS                              \
+    {                                               \
+        kCLOCK_IpInvalid, kCLOCK_Can1, kCLOCK_Can2, \
+    }
+
+/*! @brief Clock ip name array for LPUART. */
+#define LPUART_CLOCKS                                                                                     \
+    {                                                                                                     \
+        kCLOCK_IpInvalid, kCLOCK_Lpuart1, kCLOCK_Lpuart2, kCLOCK_Lpuart3, kCLOCK_Lpuart4, kCLOCK_Lpuart5, \
+            kCLOCK_Lpuart6, kCLOCK_Lpuart7, kCLOCK_Lpuart8                                                \
+    }
+
+/*! @brief Clock ip name array for SAI. */
+#define SAI_CLOCKS                                               \
+    {                                                            \
+        kCLOCK_IpInvalid, kCLOCK_Sai1, kCLOCK_Sai2, kCLOCK_Sai3, \
+    }
+
+/*! @brief Clock ip name array for PDM. */
+#define PDM_CLOCKS \
+    {              \
+        kCLOCK_Pdm \
+    }
+
+/*! @brief Clock ip name array for ENET QOS. */
+#define ENETQOS_CLOCKS  \
+    {                   \
+        kCLOCK_Enet_Qos \
+    }
+
+/*! @brief Clock ip name array for ENET. */
+#define ENET_CLOCKS  \
+    {                \
+        kCLOCK_Enet1 \
+    }
+
+/*! @brief Clock ip name array for I3C. */
+#define I3C_CLOCKS                                 \
+    {                                              \
+        kCLOCK_IpInvalid, kCLOCK_I3c1, kCLOCK_I3c2 \
+    }
+
+/*******************************************************************************
+ * Clock Root APIs
+ ******************************************************************************/
+
+/*!
+ * @brief Set CCM Root Clock MUX node to certain value.
+ *
+ * @param root Which root clock node to set, see \ref clock_root_t.
+ * @param src Clock mux value to set, different mux has different value range. See \ref clock_root_mux_source_t.
+ */
+static inline void CLOCK_SetRootClockMux(clock_root_t root, uint8_t src)
+{
+    assert(src < 8U);
+    CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW =
+        (CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & ~(CCM_CLOCK_ROOT_MUX_MASK)) | CCM_CLOCK_ROOT_MUX(src);
+    __DSB();
+    __ISB();
+}
+
+/*!
+ * @brief Get CCM Root Clock MUX value.
+ *
+ * @param root Which root clock node to get, see \ref clock_root_t.
+ * @return Clock mux value.
+ */
+static inline uint32_t CLOCK_GetRootClockMux(clock_root_t root)
+{
+    return (CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & CCM_CLOCK_ROOT_MUX_MASK) >> CCM_CLOCK_ROOT_MUX_SHIFT;
+}
+
+/*!
+ * @brief Get CCM Root Clock Source.
+ *
+ * @param root Which root clock node to get, see \ref clock_root_t.
+ * @param src Clock mux value to get, see \ref clock_root_mux_source_t.
+ * @return Clock source
+ */
+static inline clock_name_t CLOCK_GetRootClockSource(clock_root_t root, uint32_t src)
+{
+    return s_clockSourceName[root][src];
+}
+
+/*!
+ * @brief Set CCM Root Clock DIV certain value.
+ *
+ * @param root Which root clock to set, see \ref clock_root_t.
+ * @param div Clock div value to set, different divider has different value range.
+ */
+static inline void CLOCK_SetRootClockDiv(clock_root_t root, uint8_t div)
+{
+    assert(div);
+    CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW =
+        (CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & ~CCM_CLOCK_ROOT_DIV_MASK) |
+        CCM_CLOCK_ROOT_DIV((uint32_t)div - 1UL);
+    __DSB();
+    __ISB();
+}
+
+/*!
+ * @brief Get CCM DIV node value.
+ *
+ * @param root Which root clock node to get, see \ref clock_root_t.
+ * @return divider set for this root
+ */
+static inline uint32_t CLOCK_GetRootClockDiv(clock_root_t root)
+{
+    return ((CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & CCM_CLOCK_ROOT_DIV_MASK) >> CCM_CLOCK_ROOT_DIV_SHIFT) +
+           1UL;
+}
+
+/*!
+ * @brief Power Off Root Clock
+ *
+ * @param root Which root clock node to set, see \ref clock_root_t.
+ */
+static inline void CLOCK_PowerOffRootClock(clock_root_t root)
+{
+    if (0UL == (CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW & CCM_CLOCK_ROOT_OFF_MASK))
+    {
+        CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.SET = CCM_CLOCK_ROOT_OFF_MASK;
+        __DSB();
+        __ISB();
+    }
+}
+
+/*!
+ * @brief Power On Root Clock
+ *
+ * @param root Which root clock node to set, see \ref clock_root_t.
+ */
+static inline void CLOCK_PowerOnRootClock(clock_root_t root)
+{
+    CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.CLR = CCM_CLOCK_ROOT_OFF_MASK;
+    __DSB();
+    __ISB();
+}
+
+/*!
+ * @brief Configure Root Clock
+ *
+ * @param root Which root clock node to set, see \ref clock_root_t.
+ * @param config root clock config, see \ref clock_root_config_t
+ */
+static inline void CLOCK_SetRootClock(clock_root_t root, const clock_root_config_t *config)
+{
+    assert(config);
+    CCM_CTRL->CLOCK_ROOT[root].CLOCK_ROOT_CONTROL.RW = CCM_CLOCK_ROOT_MUX(config->mux) |
+                                                       CCM_CLOCK_ROOT_DIV((uint32_t)config->div - 1UL) |
+                                                       (config->clockOff ? CCM_CLOCK_ROOT_OFF(config->clockOff) : 0UL);
+    __DSB();
+    __ISB();
+}
+
+/*******************************************************************************
+ * Clock Gate APIs
+ ******************************************************************************/
+
+/*!
+ * @brief Control the clock gate for specific IP.
+ *
+ * @note This API will not have any effect when this clock is in CPULPM or SetPoint Mode
+ *
+ * @param name  Which clock to enable, see \ref clock_lpcg_t.
+ * @param value Clock gate value to set, see \ref clock_gate_value_t.
+ */
+static inline void CLOCK_ControlGate(clock_ip_name_t name, clock_gate_value_t value)
+{
+    if (((uint32_t)value & CCM_LPCG_DIRECT_ON_MASK) != (CCM_CTRL->LPCG[name].DIRECT & CCM_LPCG_DIRECT_ON_MASK))
+    {
+        CCM_CTRL->LPCG[name].DIRECT = ((uint32_t)value & CCM_LPCG_DIRECT_ON_MASK);
+        __DSB();
+        __ISB();
+    }
+}
+
+/*!
+ * @brief Enable the clock for specific IP.
+ *
+ * @param name  Which clock to enable, see \ref clock_lpcg_t.
+ */
+static inline void CLOCK_EnableClock(clock_ip_name_t name)
+{
+    CLOCK_ControlGate(name, kCLOCK_On);
+}
+
+/*!
+ * @brief Disable the clock for specific IP.
+ *
+ * @param name  Which clock to disable, see \ref clock_lpcg_t.
+ */
+static inline void CLOCK_DisableClock(clock_ip_name_t name)
+{
+    CLOCK_ControlGate(name, kCLOCK_Off);
+}
+
+/*******************************************************************************
+ * Other APIs
+ ******************************************************************************/
+
+/*
+ * Setup a variable for clock source frequencies
+ */
+extern volatile uint32_t g_clockSourceFreq[kCLOCK_Ext + 1];
+
+/*!
+ * @brief Gets the clock frequency for a specific IP module.
+ *
+ * This function gets the IP module clock frequency.
+ *
+ * @param name Which root clock to get, see \ref clock_root_t.
+ * @return Clock frequency value in hertz
+ */
+uint32_t CLOCK_GetIpFreq(clock_root_t name);
+
+#endif

--- a/devices/MIMX9352/drivers/fsl_edma_soc.c
+++ b/devices/MIMX9352/drivers/fsl_edma_soc.c
@@ -1,0 +1,527 @@
+/*
+ * Copyright 2022 NXP
+ * All rights reserved.
+ *
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "fsl_edma_soc.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.edma_soc"
+#endif
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+extern void EDMA_DriverIRQHandler(uint32_t instance, uint32_t channel);
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+/*!
+ * brief DMA instance 1, channel 0~1 IRQ handler.
+ *
+ */
+void DMA4_0_1_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 0 */
+    EDMA_DriverIRQHandler(1U, 0U);
+    /* Instance 1 channel 1 */
+    EDMA_DriverIRQHandler(1U, 1U);
+}
+
+/*!
+ * brief DMA instance 1, channel 2~3 IRQ handler.
+ *
+ */
+void DMA4_2_3_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 2 */
+    EDMA_DriverIRQHandler(1U, 2U);
+    /* Instance 1 channel 3 */
+    EDMA_DriverIRQHandler(1U, 3U);
+}
+
+/*!
+ * brief DMA instance 1, channel 4~5 IRQ handler.
+ *
+ */
+void DMA4_4_5_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 4 */
+    EDMA_DriverIRQHandler(1U, 4U);
+    /* Instance 1 channel 5 */
+    EDMA_DriverIRQHandler(1U, 5U);
+}
+
+/*!
+ * brief DMA instance 1, channel 6~7 IRQ handler.
+ *
+ */
+void DMA4_6_7_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 6 */
+    EDMA_DriverIRQHandler(1U, 6U);
+    /* Instance 1 channel 7 */
+    EDMA_DriverIRQHandler(1U, 7U);
+}
+
+/*!
+ * brief DMA instance 1, channel 8~9 IRQ handler.
+ *
+ */
+void DMA4_8_9_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 8 */
+    EDMA_DriverIRQHandler(1U, 8U);
+    /* Instance 1 channel 9 */
+    EDMA_DriverIRQHandler(1U, 9U);
+}
+
+/*!
+ * brief DMA instance 1, channel 10~11 IRQ handler.
+ *
+ */
+void DMA4_10_11_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 10 */
+    EDMA_DriverIRQHandler(1U, 10U);
+    /* Instance 1 channel 11 */
+    EDMA_DriverIRQHandler(1U, 11U);
+}
+
+/*!
+ * brief DMA instance 1, channel 12~13 IRQ handler.
+ *
+ */
+void DMA4_12_13_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 12 */
+    EDMA_DriverIRQHandler(1U, 12U);
+    /* Instance 1 channel 13 */
+    EDMA_DriverIRQHandler(1U, 13U);
+}
+
+/*!
+ * brief DMA instance 1, channel 14~15 IRQ handler.
+ *
+ */
+void DMA4_14_15_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 14 */
+    EDMA_DriverIRQHandler(1U, 14U);
+    /* Instance 1 channel 15 */
+    EDMA_DriverIRQHandler(1U, 15U);
+}
+
+/*!
+ * brief DMA instance 1, channel 16~17 IRQ handler.
+ *
+ */
+void DMA4_16_17_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 16 */
+    EDMA_DriverIRQHandler(1U, 16U);
+    /* Instance 1 channel 17 */
+    EDMA_DriverIRQHandler(1U, 17U);
+}
+
+/*!
+ * brief DMA instance 1, channel 18~19 IRQ handler.
+ *
+ */
+void DMA4_18_19_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 18 */
+    EDMA_DriverIRQHandler(1U, 18U);
+    /* Instance 1 channel 19 */
+    EDMA_DriverIRQHandler(1U, 19U);
+}
+
+/*!
+ * brief DMA instance 1, channel 20~21 IRQ handler.
+ *
+ */
+void DMA4_20_21_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 20 */
+    EDMA_DriverIRQHandler(1U, 20U);
+    /* Instance 1 channel 21 */
+    EDMA_DriverIRQHandler(1U, 21U);
+}
+
+/*!
+ * brief DMA instance 1, channel 22~23 IRQ handler.
+ *
+ */
+void DMA4_22_23_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 22 */
+    EDMA_DriverIRQHandler(1U, 22U);
+    /* Instance 1 channel 23 */
+    EDMA_DriverIRQHandler(1U, 23U);
+}
+
+/*!
+ * brief DMA instance 1, channel 24~25 IRQ handler.
+ *
+ */
+void DMA4_24_25_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 24 */
+    EDMA_DriverIRQHandler(1U, 24U);
+    /* Instance 1 channel 25 */
+    EDMA_DriverIRQHandler(1U, 25U);
+}
+
+/*!
+ * brief DMA instance 1, channel 26~27 IRQ handler.
+ *
+ */
+void DMA4_26_27_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 26 */
+    EDMA_DriverIRQHandler(1U, 26U);
+    /* Instance 1 channel 27 */
+    EDMA_DriverIRQHandler(1U, 27U);
+}
+
+/*!
+ * brief DMA instance 1, channel 28~29 IRQ handler.
+ *
+ */
+void DMA4_28_29_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 28 */
+    EDMA_DriverIRQHandler(1U, 28U);
+    /* Instance 1 channel 29 */
+    EDMA_DriverIRQHandler(1U, 29U);
+}
+
+/*!
+ * brief DMA instance 1, channel 30~31 IRQ handler.
+ *
+ */
+void DMA4_30_31_DriverIRQHandler(void)
+{
+    /* Instance 1 channel 30 */
+    EDMA_DriverIRQHandler(1U, 30U);
+    /* Instance 1 channel 31 */
+    EDMA_DriverIRQHandler(1U, 31U);
+}
+
+/*!
+ * brief DMA instance 0, channel 0 IRQ handler.
+ *
+ */
+void DMA_0_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 0 */
+    EDMA_DriverIRQHandler(0U, 0U);
+}
+
+/*!
+ * brief DMA instance 0, channel 1 IRQ handler.
+ *
+ */
+void DMA_1_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 1 */
+    EDMA_DriverIRQHandler(0U, 1U);
+}
+
+/*!
+ * brief DMA instance 0, channel 2 IRQ handler.
+ *
+ */
+void DMA_2_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 2 */
+    EDMA_DriverIRQHandler(0U, 2U);
+}
+
+/*!
+ * brief DMA instance 0, channel 3 IRQ handler.
+ *
+ */
+void DMA_3_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 3 */
+    EDMA_DriverIRQHandler(0U, 3U);
+}
+
+/*!
+ * brief DMA instance 0, channel 4 IRQ handler.
+ *
+ */
+void DMA_4_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 4 */
+    EDMA_DriverIRQHandler(0U, 4U);
+}
+
+/*!
+ * brief DMA instance 0, channel 5 IRQ handler.
+ *
+ */
+void DMA_5_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 5 */
+    EDMA_DriverIRQHandler(0U, 5U);
+}
+
+/*!
+ * brief DMA instance 0, channel 6 IRQ handler.
+ *
+ */
+void DMA_6_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 6 */
+    EDMA_DriverIRQHandler(0U, 6U);
+}
+
+/*!
+ * brief DMA instance 0, channel 7 IRQ handler.
+ *
+ */
+void DMA_7_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 7 */
+    EDMA_DriverIRQHandler(0U, 7U);
+}
+
+/*!
+ * brief DMA instance 0, channel 8 IRQ handler.
+ *
+ */
+void DMA_8_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 8 */
+    EDMA_DriverIRQHandler(0U, 8U);
+}
+
+/*!
+ * brief DMA instance 0, channel 9 IRQ handler.
+ *
+ */
+void DMA_9_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 9 */
+    EDMA_DriverIRQHandler(0U, 9U);
+}
+
+/*!
+ * brief DMA instance 0, channel 10 IRQ handler.
+ *
+ */
+void DMA_10_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 10 */
+    EDMA_DriverIRQHandler(0U, 10U);
+}
+
+/*!
+ * brief DMA instance 0, channel 11 IRQ handler.
+ *
+ */
+void DMA_11_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 11 */
+    EDMA_DriverIRQHandler(0U, 11U);
+}
+
+/*!
+ * brief DMA instance 0, channel 12 IRQ handler.
+ *
+ */
+void DMA_12_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 12 */
+    EDMA_DriverIRQHandler(0U, 12U);
+}
+
+/*!
+ * brief DMA instance 0, channel 13 IRQ handler.
+ *
+ */
+void DMA_13_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 13 */
+    EDMA_DriverIRQHandler(0U, 13U);
+}
+
+/*!
+ * brief DMA instance 0, channel 14 IRQ handler.
+ *
+ */
+void DMA_14_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 14 */
+    EDMA_DriverIRQHandler(0U, 14U);
+}
+
+/*!
+ * brief DMA instance 0, channel 15 IRQ handler.
+ *
+ */
+void DMA_15_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 15 */
+    EDMA_DriverIRQHandler(0U, 15U);
+}
+
+/*!
+ * brief DMA instance 0, channel 16 IRQ handler.
+ *
+ */
+void DMA_16_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 16 */
+    EDMA_DriverIRQHandler(0U, 16U);
+}
+
+/*!
+ * brief DMA instance 0, channel 17 IRQ handler.
+ *
+ */
+void DMA_17_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 17 */
+    EDMA_DriverIRQHandler(0U, 17U);
+}
+
+/*!
+ * brief DMA instance 0, channel 18 IRQ handler.
+ *
+ */
+void DMA_18_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 18 */
+    EDMA_DriverIRQHandler(0U, 18U);
+}
+
+/*!
+ * brief DMA instance 0, channel 19 IRQ handler.
+ *
+ */
+void DMA_19_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 19 */
+    EDMA_DriverIRQHandler(0U, 19U);
+}
+
+/*!
+ * brief DMA instance 0, channel 20 IRQ handler.
+ *
+ */
+void DMA_20_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 20 */
+    EDMA_DriverIRQHandler(0U, 20U);
+}
+
+/*!
+ * brief DMA instance 0, channel 21 IRQ handler.
+ *
+ */
+void DMA_21_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 21 */
+    EDMA_DriverIRQHandler(0U, 21U);
+}
+
+/*!
+ * brief DMA instance 0, channel 22 IRQ handler.
+ *
+ */
+void DMA_22_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 22 */
+    EDMA_DriverIRQHandler(0U, 22U);
+}
+
+/*!
+ * brief DMA instance 0, channel 23 IRQ handler.
+ *
+ */
+void DMA_23_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 23 */
+    EDMA_DriverIRQHandler(0U, 23U);
+}
+
+/*!
+ * brief DMA instance 0, channel 24 IRQ handler.
+ *
+ */
+void DMA_24_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 24 */
+    EDMA_DriverIRQHandler(0U, 24U);
+}
+
+/*!
+ * brief DMA instance 0, channel 25 IRQ handler.
+ *
+ */
+void DMA_25_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 25 */
+    EDMA_DriverIRQHandler(0U, 25U);
+}
+
+/*!
+ * brief DMA instance 0, channel 26 IRQ handler.
+ *
+ */
+void DMA_26_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 26 */
+    EDMA_DriverIRQHandler(0U, 26U);
+}
+
+/*!
+ * brief DMA instance 0, channel 27 IRQ handler.
+ *
+ */
+void DMA_27_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 27 */
+    EDMA_DriverIRQHandler(0U, 27U);
+}
+
+/*!
+ * brief DMA instance 0, channel 28 IRQ handler.
+ *
+ */
+void DMA_28_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 28 */
+    EDMA_DriverIRQHandler(0U, 28U);
+}
+
+/*!
+ * brief DMA instance 0, channel 29 IRQ handler.
+ *
+ */
+void DMA_29_DriverIRQHandler(void)
+{
+    /* Instance 0 channel 29 */
+    EDMA_DriverIRQHandler(0U, 29U);
+}
+
+/*!
+ * brief DMA instance 0, channel 30 IRQ handler.
+ *
+ */
+void DMA_30_DriverIRQHandler(void)
+{
+    /* Instance0 channel 30 */
+    EDMA_DriverIRQHandler(0U, 30U);
+}

--- a/devices/MIMX9352/drivers/fsl_edma_soc.h
+++ b/devices/MIMX9352/drivers/fsl_edma_soc.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2022 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _FSL_EDMA_SOC_H_
+#define _FSL_EDMA_SOC_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup edma_soc
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*! @name Driver version */
+/*@{*/
+/*! @brief Driver version 2.0.0. */
+#define FSL_EDMA_SOC_DRIVER_VERSION (MAKE_VERSION(2, 0, 0))
+/*@}*/
+
+/*!@brief DMA IP version */
+#define FSL_EDMA_SOC_IP_DMA3 (1)
+#define FSL_EDMA_SOC_IP_DMA4 (1)
+
+/*!@brief DMA base table */
+#define EDMA_BASE_PTRS \
+    {                  \
+        DMA3, DMA4     \
+    }
+
+#define EDMA_CHN_IRQS                                                                                                 \
+    {                                                                                                                 \
+        {DMA_0_IRQn,  DMA_1_IRQn,  DMA_2_IRQn,  DMA_3_IRQn,  DMA_4_IRQn,  DMA_5_IRQn,  DMA_6_IRQn,  DMA_7_IRQn,       \
+         DMA_8_IRQn,  DMA_9_IRQn,  DMA_10_IRQn, DMA_11_IRQn, DMA_12_IRQn, DMA_13_IRQn, DMA_14_IRQn, DMA_15_IRQn,      \
+         DMA_16_IRQn, DMA_17_IRQn, DMA_18_IRQn, DMA_19_IRQn, DMA_20_IRQn, DMA_21_IRQn, DMA_22_IRQn, DMA_23_IRQn,      \
+         DMA_24_IRQn, DMA_25_IRQn, DMA_26_IRQn, DMA_27_IRQn, DMA_28_IRQn, DMA_29_IRQn, DMA_30_IRQn},                  \
+        {                                                                                                             \
+            DMA4_0_1_IRQn, DMA4_0_1_IRQn, DMA4_2_3_IRQn, DMA4_2_3_IRQn, DMA4_4_5_IRQn, DMA4_4_5_IRQn, DMA4_6_7_IRQn,  \
+                DMA4_6_7_IRQn, DMA4_8_9_IRQn, DMA4_8_9_IRQn, DMA4_10_11_IRQn, DMA4_10_11_IRQn, DMA4_12_13_IRQn,       \
+                DMA4_12_13_IRQn, DMA4_14_15_IRQn, DMA4_14_15_IRQn, DMA4_16_17_IRQn, DMA4_16_17_IRQn, DMA4_18_19_IRQn, \
+                DMA4_18_19_IRQn, DMA4_20_21_IRQn, DMA4_20_21_IRQn, DMA4_22_23_IRQn, DMA4_22_23_IRQn, DMA4_24_25_IRQn, \
+                DMA4_24_25_IRQn, DMA4_26_27_IRQn, DMA4_26_27_IRQn, DMA4_28_29_IRQn, DMA4_28_29_IRQn, DMA4_30_31_IRQn, \
+                DMA4_30_31_IRQn, DMA4_32_33_IRQn, DMA4_32_33_IRQn, DMA4_34_35_IRQn, DMA4_34_35_IRQn, DMA4_36_37_IRQn, \
+                DMA4_36_37_IRQn, DMA4_38_39_IRQn, DMA4_38_39_IRQn, DMA4_40_41_IRQn, DMA4_40_41_IRQn, DMA4_42_43_IRQn, \
+                DMA4_42_43_IRQn, DMA4_44_45_IRQn, DMA4_44_45_IRQn, DMA4_46_47_IRQn, DMA4_46_47_IRQn, DMA4_48_49_IRQn, \
+                DMA4_48_49_IRQn, DMA4_50_51_IRQn, DMA4_50_51_IRQn, DMA4_52_53_IRQn, DMA4_52_53_IRQn, DMA4_54_55_IRQn, \
+                DMA4_54_55_IRQn, DMA4_56_57_IRQn, DMA4_56_57_IRQn, DMA4_58_59_IRQn, DMA4_58_59_IRQn, DMA4_60_61_IRQn, \
+                DMA4_60_61_IRQn, DMA4_62_63_IRQn, DMA4_62_63_IRQn                                                     \
+        }                                                                                                             \
+    }
+
+#ifndef DMA_CH_MUX_SRC_MASK
+#define DMA_CH_MUX_SRC_MASK  (0x7FU)
+#define DMA_CH_MUX_SRC_SHIFT (0U)
+#define DMA_CH_MUX_SRC(x)    (((uint32_t)(((uint32_t)(x)) << DMA_CH_MUX_SRC_SHIFT)) & DMA_CH_MUX_SRC_MASK)
+#endif
+
+/*!@brief dma request source */
+typedef enum _dma_request_source
+{
+    kDmaRequestDisabled                 = 0U,           /**< DSisabled*/
+    kDma3RequestMuxCAN1                 = 1U | 0x100U,  /**< CAN1 */
+    kDma3RequestMuxGPIO1Request0        = 3U | 0x100U,  /**< GPIO1 channel 0 */
+    kDma3RequestMuxGPIO1Request1        = 4U | 0x100U,  /**< GPIO1 channel 1 */
+    kDma3RequestMuxI3C1ToBusRequest     = 5U | 0x100U,  /**< I3C1 To-bus Request */
+    kDma3RequestMuxI3C1FromBusRequest   = 6U | 0x100U,  /**< I3C1 From-bus Request */
+    kDma3RequestMuxLPI2C1Tx             = 7U | 0x100U,  /**< LPI2C1 */
+    kDma3RequestMuxLPI2C1Rx             = 8U | 0x100U,  /**< LPI2C1 */
+    kDma3RequestMuxLPI2C2Tx             = 9U | 0x100U,  /**< LPI2C2 */
+    kDma3RequestMuxLPI2C2Rx             = 10U | 0x100U, /**< LPI2C2 */
+    kDma3RequestMuxLPSPI1Tx             = 11U | 0x100U, /**< LPSPI1 Transmit */
+    kDma3RequestMuxLPSPI1Rx             = 12U | 0x100U, /**< LPSPI1 Receive */
+    kDma3RequestMuxLPSPI2Tx             = 13U | 0x100U, /**< LPSPI2 Transmit */
+    kDma3RequestMuxLPSPI2Rx             = 14U | 0x100U, /**< LPSPI2 Receive */
+    kDma3RequestMuxLPTMR1Request        = 15U | 0x100U, /**< LPTMR1 Request */
+    kDma3RequestMuxLPUART1Tx            = 16U | 0x100U, /**< LPUART1 Transmit */
+    kDma3RequestMuxLPUART1Rx            = 17U | 0x100U, /**< LPUART1 Receive */
+    kDma3RequestMuxLPUART2Tx            = 18U | 0x100U, /**< LPUART2 Transmit */
+    kDma3RequestMuxLPUART2Rx            = 19U | 0x100U, /**< LPUART2 Receive */
+    kDma3RequestMuxEdgelockRequest      = 20U | 0x100U, /**< Edgelock enclave DMA Request */
+    kDma3RequestMuxSai1Tx               = 21U | 0x100U, /**< SAI1 Transmit */
+    kDma3RequestMuxSai1Rx               = 22U | 0x100U, /**< SAI1 Receive */
+    kDma3RequestMuxTPM1Request0Request2 = 23U | 0x100U, /**< TPM1 request 0 and request 2 */
+    kDma3RequestMuxTPM1Request1Request3 = 24U | 0x100U, /**< TPM1 request 1 and request 3 */
+    kDma3RequestMuxTPM1OverflowRequest  = 25U | 0x100U, /**< TPM1 Overflow request */
+    kDma3RequestMuxTPM2Request0Request2 = 26U | 0x100U, /**< TPM2 request 0 and request 2 */
+    kDma3RequestMuxTPM2Request1Request3 = 27U | 0x100U, /**< TPM2 request 1 and request 3 */
+    kDma3RequestMuxTPM2OverflowRequest  = 28U | 0x100U, /**< TPM2 Overflow request */
+    kDma3RequestMuxPDMRequest           = 29U | 0x100U, /**< PDM */
+    kDma3RequestMuxADC1Request          = 30U | 0x100U, /**< ADC1 */
+    kDma4RequestMuxCAN2                 = 1U | 0x200U,  /**< CAN2 */
+    kDma4RequestMuxGPIO2Request0        = 2U | 0x200U,  /**< GPIO2 channel 0 */
+    kDma4RequestMuxGPIO2Request1        = 3U | 0x200U,  /**< GPIO2 channel 1 */
+    kDma4RequestMuxGPIO3Request0        = 4U | 0x200U,  /**< GPIO3 channel 0 */
+    kDma4RequestMuxGPIO3Request1        = 5U | 0x200U,  /**< GPIO3 channel 1 */
+    kDma4RequestMuxI3C2ToBusRequest     = 6U | 0x200U,  /**< I3C2 To-bus Request */
+    kDma4RequestMuxI3C2FromBusRequest   = 7U | 0x200U,  /**< I3C2 From-bus Request */
+    kDma4RequestMuxLPI2C3Tx             = 8U | 0x200U,  /**< LPI2C3 */
+    kDma4RequestMuxLPI2C3Rx             = 9U | 0x200U,  /**< LPI2C3 */
+    kDma4RequestMuxLPI2C4Tx             = 10U | 0x200U, /**< LPI2C4 */
+    kDma4RequestMuxLPI2C4Rx             = 11U | 0x200U, /**< LPI2C4 */
+    kDma4RequestMuxLPSPI3Tx             = 12U | 0x200U, /**< LPSPI3 Transmit */
+    kDma4RequestMuxLPSPI3Rx             = 13U | 0x200U, /**< LPSPI3 Receive */
+    kDma4RequestMuxLPSPI4Tx             = 14U | 0x200U, /**< LPSPI4 Transmit */
+    kDma4RequestMuxLPSPI4Rx             = 15U | 0x200U, /**< LPSPI4 Receive */
+    kDma4RequestMuxLPTMR2Request        = 16U | 0x200U, /**< LPTMR2 Request */
+    kDma4RequestMuxLPUART3Tx            = 17U | 0x200U, /**< LPUART3 Transmit */
+    kDma4RequestMuxLPUART3Rx            = 18U | 0x200U, /**< LPUART3 Receive */
+    kDma4RequestMuxLPUART4Tx            = 19U | 0x200U, /**< LPUART4 Transmit */
+    kDma4RequestMuxLPUART4Rx            = 20U | 0x200U, /**< LPUART4 Receive */
+    kDma4RequestMuxLPUART5Tx            = 21U | 0x200U, /**< LPUART5 Transmit */
+    kDma4RequestMuxLPUART5Rx            = 22U | 0x200U, /**< LPUART5 Receive */
+    kDma4RequestMuxLPUART6Tx            = 23U | 0x200U, /**< LPUART6 Transmit */
+    kDma4RequestMuxLPUART6Rx            = 24U | 0x200U, /**< LPUART6 Receive */
+    kDma4RequestMuxTPM3Request0Request2 = 25U | 0x200U, /**< TPM3 request 0 and request 2 */
+    kDma4RequestMuxTPM3Request1Request3 = 26U | 0x200U, /**< TPM3 request 1 and request 3 */
+    kDma4RequestMuxTPM3OverflowRequest  = 27U | 0x200U, /**< TPM3 Overflow request */
+    kDma4RequestMuxTPM4Request0Request2 = 28U | 0x200U, /**< TPM4 request 0 and request 2 */
+    kDma4RequestMuxTPM4Request1Request3 = 29U | 0x200U, /**< TPM4 request 1 and request 3 */
+    kDma4RequestMuxTPM4OverflowRequest  = 30U | 0x200U, /**< TPM4 Overflow request */
+    kDma4RequestMuxTPM5Request0Request2 = 31U | 0x200U, /**< TPM5 request 0 and request 2 */
+    kDma4RequestMuxTPM5Request1Request3 = 32U | 0x200U, /**< TPM5 request 1 and request 3 */
+    kDma4RequestMuxTPM5OverflowRequest  = 33U | 0x200U, /**< TPM5 Overflow request */
+    kDma4RequestMuxTPM6Request0Request2 = 34U | 0x200U, /**< TPM6 request 0 and request 2 */
+    kDma4RequestMuxTPM6Request1Request3 = 35U | 0x200U, /**< TPM6 request 1 and request 3 */
+    kDma4RequestMuxTPM6OverflowRequest  = 36U | 0x200U, /**< TPM6 Overflow request */
+    kDma4RequestMuxFlexIO1Request0      = 37U | 0x200U, /**< FlexIO1 Request0 */
+    kDma4RequestMuxFlexIO1Request1      = 38U | 0x200U, /**< FlexIO1 Request1 */
+    kDma4RequestMuxFlexIO1Request2      = 39U | 0x200U, /**< FlexIO1 Request2 */
+    kDma4RequestMuxFlexIO1Request3      = 40U | 0x200U, /**< FlexIO1 Request3 */
+    kDma4RequestMuxFlexIO1Request4      = 41U | 0x200U, /**< FlexIO1 Request4 */
+    kDma4RequestMuxFlexIO1Request5      = 42U | 0x200U, /**< FlexIO1 Request5 */
+    kDma4RequestMuxFlexIO1Request6      = 43U | 0x200U, /**< FlexIO1 Request6 */
+    kDma4RequestMuxFlexIO1Request7      = 44U | 0x200U, /**< FlexIO1 Request7 */
+    kDma4RequestMuxFlexIO2Request0      = 45U | 0x200U, /**< FlexIO2 Request0 */
+    kDma4RequestMuxFlexIO2Request1      = 46U | 0x200U, /**< FlexIO2 Request1 */
+    kDma4RequestMuxFlexIO2Request2      = 47U | 0x200U, /**< FlexIO2 Request2 */
+    kDma4RequestMuxFlexIO2Request3      = 48U | 0x200U, /**< FlexIO2 Request3 */
+    kDma4RequestMuxFlexIO2Request4      = 49U | 0x200U, /**< FlexIO2 Request4 */
+    kDma4RequestMuxFlexIO2Request5      = 50U | 0x200U, /**< FlexIO2 Request5 */
+    kDma4RequestMuxFlexIO2Request6      = 51U | 0x200U, /**< FlexIO2 Request6 */
+    kDma4RequestMuxFlexIO2Request7      = 52U | 0x200U, /**< FlexIO2 Request7 */
+    kDma4RequestMuxFlexSPI1Tx           = 53U | 0x200U, /**< FlexSPI1 Transmit */
+    kDma4RequestMuxSai2Tx               = 58U | 0x200U, /**< SAI2 Transmit */
+    kDma4RequestMuxSai2Rx               = 59U | 0x200U, /**< SAI2 Receive */
+    kDma4RequestMuxSai3Tx               = 60U | 0x200U, /**< SAI3 Transmit */
+    kDma4RequestMuxSai3Rx               = 61U | 0x200U, /**< SAI3 Receive */
+    kDma4RequestMuxGPIO4Request0        = 62U | 0x200U, /**< GPIO4 channel 0 */
+    kDma4RequestMuxGPIO4Request1        = 63U | 0x200U, /**< GPIO4 channel 1 */
+    kDma4RequestMuxSPDIFRequest         = 65U | 0x200U, /**< SPDIF */
+    kDma4RequestMuxSPDIFRequest1        = 66U | 0x200U, /**< SPDIF */
+    kDma4RequestMuxENETRequest          = 67U | 0x200U, /**< ENET */
+    kDma4RequestMuxENETRequest1         = 68U | 0x200U, /**< ENET */
+    kDma4RequestMuxENETRequest2         = 69U | 0x200U, /**< ENET */
+    kDma4RequestMuxENETRequest3         = 70U | 0x200U, /**< ENET */
+    kDma4RequestMuxLPI2C5Tx             = 71U | 0x200U, /**< LPI2C5 */
+    kDma4RequestMuxLPI2C5Rx             = 72U | 0x200U, /**< LPI2C5 */
+    kDma4RequestMuxLPI2C6Tx             = 73U | 0x200U, /**< LPI2C6 */
+    kDma4RequestMuxLPI2C6Rx             = 74U | 0x200U, /**< LPI2C6 */
+    kDma4RequestMuxLPI2C7Tx             = 75U | 0x200U, /**< LPI2C7 */
+    kDma4RequestMuxLPI2C7Rx             = 76U | 0x200U, /**< LPI2C7 */
+    kDma4RequestMuxLPI2C8Tx             = 77U | 0x200U, /**< LPI2C8 */
+    kDma4RequestMuxLPI2C8Rx             = 78U | 0x200U, /**< LPI2C8 */
+    kDma4RequestMuxLPSPI5Tx             = 79U | 0x200U, /**< LPSPI5 Transmit */
+    kDma4RequestMuxLPSPI5Rx             = 80U | 0x200U, /**< LPSPI5 Receive */
+    kDma4RequestMuxLPSPI6Tx             = 81U | 0x200U, /**< LPSPI6 Transmit */
+    kDma4RequestMuxLPSPI6Rx             = 82U | 0x200U, /**< LPSPI6 Receive */
+    kDma4RequestMuxLPSPI7Tx             = 83U | 0x200U, /**< LPSPI7 Transmit */
+    kDma4RequestMuxLPSPI7Rx             = 84U | 0x200U, /**< LPSPI7 Receive */
+    kDma4RequestMuxLPSPI8Tx             = 85U | 0x200U, /**< LPSPI8 Transmit */
+    kDma4RequestMuxLPSPI8Rx             = 86U | 0x200U, /**< LPSPI8 Receive */
+    kDma4RequestMuxLPUART7Tx            = 87U | 0x200U, /**< LPUART7 Transmit */
+    kDma4RequestMuxLPUART7Rx            = 88U | 0x200U, /**< LPUART7 Receive */
+    kDma4RequestMuxLPUART8Tx            = 89U | 0x200U, /**< LPUART8 Transmit */
+    kDma4RequestMuxLPUART8Rx            = 90U | 0x200U, /**< LPUART8 Receive */
+    kDma4RequestMuxENET_QOSRequest      = 91U | 0x200U, /**< ENET_QOS */
+    kDma4RequestMuxENET_QOSRequest1     = 92U | 0x200U, /**< ENET_QOS */
+    kDma4RequestMuxENET_QOSRequest2     = 93U | 0x200U, /**< ENET_QOS */
+    kDma4RequestMuxENET_QOSRequest3     = 94U | 0x200U, /**< ENET_QOS */
+} dma_request_source_t;
+
+/*!< Verify dma base and request source */
+#define EDMA_CHANNEL_HAS_REQUEST_SOURCE(base, source) ((base) == DMA3 ? ((source)&0x100U) : ((source)&0x200U))
+
+#define FSL_FEATURE_EDMA_MODULE_CHANNEL(base)                    (base == DMA3 ? 31U : 64U)
+#define FSL_FEATURE_EDMA_MODULE_MAX_CHANNEL                      (64)
+#define FSL_FEATURE_EDMA_HAS_GLOBAL_MASTER_ID_REPLICATION        (1)
+#define FSL_FEATURE_EDMA_HAS_CONTINUOUS_LINK_MODE                (0)
+#define FSL_FEATURE_EDMA_MODULE_COUNT                            (2)
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_CONFIG                      (1)
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_SWAP_SIZE                   (1)
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_ACCESS_TYPE                 (1)
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_MEMRORY_ATTRIBUTE           (1)
+#define FSL_FEATURE_EDMA_HAS_CHANNEL_SIGN_EXTENSION              (1)
+#define FSL_FEATURE_EDMA_MODULE_SUPPORT_MATTR(base)              (base == DMA3 ? 0U : 1U)
+#define FSL_FEATURE_EDMA_MODULE_SUPPORT_SIGN_EXTENSION(base)     (base == DMA3 ? 0U : 1U)
+#define FSL_FEATURE_EDMA_MODULE_SUPPORT_SWAP(base)               (base == DMA3 ? 0U : 1U)
+#define FSL_FEATURE_EDMA_MODULE_SUPPORT_INSTR(base)              (base == DMA3 ? 0U : 1U)
+#define FSL_FEATURE_EDMA_SUPPORT_128_BYTES_TRANSFER              (1)
+#define FSL_FEATURE_EDMA_MODULE_SUPPORT_128_BYTES_TRANSFER(base) (base == DMA3 ? 0U : 1U)
+
+/*!@brief EDMA base address convert macro */
+#define EDMA_CHANNEL_OFFSET           0x10000U
+#define EDMA_CHANNEL_ARRAY_STEP(base) ((base) == DMA3 ? 0x10000U : 0x8000U)
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+/*!
+ * @}
+ */
+
+#endif /* _FSL_EDMA_SOC_H_ */

--- a/devices/MIMX9352/drivers/fsl_iomuxc.h
+++ b/devices/MIMX9352/drivers/fsl_iomuxc.h
@@ -1,0 +1,748 @@
+/*
+ * Copyright 2022 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef _FSL_IOMUXC_H_
+#define _FSL_IOMUXC_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup iomuxc_driver
+ * @{
+ */
+
+/*! @file */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.iomuxc"
+#endif
+
+/*! @name Driver version */
+/*@{*/
+/*! @brief IOMUXC driver version 1.0.0. */
+#define FSL_IOMUXC_DRIVER_VERSION (MAKE_VERSION(1, 0, 0))
+/*@}*/
+
+/*!
+ * @name Pin function ID
+ * The pin function ID is a tuple of \<muxRegister muxMode inputRegister inputDaisy configRegister\>
+ *
+ * @{
+ */
+#define IOMUXC_PAD_DAP_TDI__JTAG_MUX_TDI                          0x543c0000, 0x0, 0x543c03d8, 0x0, 0x543c01b0
+#define IOMUXC_PAD_DAP_TDI__MQS2_LEFT                             0x543c0000, 0x1, 0x543c0000, 0x0, 0x543c01b0
+#define IOMUXC_PAD_DAP_TDI__CAN2_TX                               0x543c0000, 0x3, 0x543c0000, 0x0, 0x543c01b0
+#define IOMUXC_PAD_DAP_TDI__FLEXIO2_FLEXIO30                      0x543c0000, 0x4, 0x543c0000, 0x0, 0x543c01b0
+#define IOMUXC_PAD_DAP_TDI__GPIO3_IO28                            0x543c0000, 0x5, 0x543c0000, 0x0, 0x543c01b0
+#define IOMUXC_PAD_DAP_TDI__LPUART5_RX                            0x543c0000, 0x6, 0x543c0430, 0x0, 0x543c01b0
+#define IOMUXC_PAD_DAP_TMS_SWDIO__JTAG_MUX_TMS                    0x543c0004, 0x0, 0x543c03dc, 0x0, 0x543c01b4
+#define IOMUXC_PAD_DAP_TMS_SWDIO__FLEXIO2_FLEXIO31                0x543c0004, 0x4, 0x543c0000, 0x0, 0x543c01b4
+#define IOMUXC_PAD_DAP_TMS_SWDIO__GPIO3_IO29                      0x543c0004, 0x5, 0x543c0000, 0x0, 0x543c01b4
+#define IOMUXC_PAD_DAP_TMS_SWDIO__LPUART5_RTS_B                   0x543c0004, 0x6, 0x543c0000, 0x0, 0x543c01b4
+#define IOMUXC_PAD_DAP_TCLK_SWCLK__JTAG_MUX_TCK                   0x543c0008, 0x0, 0x543c03d4, 0x0, 0x543c01b8
+#define IOMUXC_PAD_DAP_TCLK_SWCLK__FLEXIO1_FLEXIO30               0x543c0008, 0x4, 0x543c0000, 0x0, 0x543c01b8
+#define IOMUXC_PAD_DAP_TCLK_SWCLK__GPIO3_IO30                     0x543c0008, 0x5, 0x543c0000, 0x0, 0x543c01b8
+#define IOMUXC_PAD_DAP_TCLK_SWCLK__LPUART5_CTS_B                  0x543c0008, 0x6, 0x543c042c, 0x0, 0x543c01b8
+#define IOMUXC_PAD_DAP_TDO_TRACESWO__JTAG_MUX_TDO                 0x543c000c, 0x0, 0x543c0000, 0x0, 0x543c01bc
+#define IOMUXC_PAD_DAP_TDO_TRACESWO__MQS2_RIGHT                   0x543c000c, 0x1, 0x543c0000, 0x0, 0x543c01bc
+#define IOMUXC_PAD_DAP_TDO_TRACESWO__CAN2_RX                      0x543c000c, 0x3, 0x543c0364, 0x0, 0x543c01bc
+#define IOMUXC_PAD_DAP_TDO_TRACESWO__FLEXIO1_FLEXIO31             0x543c000c, 0x4, 0x543c0000, 0x0, 0x543c01bc
+#define IOMUXC_PAD_DAP_TDO_TRACESWO__GPIO3_IO31                   0x543c000c, 0x5, 0x543c0000, 0x0, 0x543c01bc
+#define IOMUXC_PAD_DAP_TDO_TRACESWO__LPUART5_TX                   0x543c000c, 0x6, 0x543c0434, 0x0, 0x543c01bc
+#define IOMUXC_PAD_GPIO_IO00__GPIO2_IO00                          0x543c0010, 0x0, 0x543c0000, 0x0, 0x543c01c0
+#define IOMUXC_PAD_GPIO_IO00__LPI2C3_SDA                          0x543c0010, 0x1, 0x543c03e4, 0x0, 0x543c01c0
+#define IOMUXC_PAD_GPIO_IO00__MEDIAMIX_CAM_CLK                    0x543c0010, 0x2, 0x543c0000, 0x0, 0x543c01c0
+#define IOMUXC_PAD_GPIO_IO00__MEDIAMIX_DISP_CLK                   0x543c0010, 0x3, 0x543c0000, 0x0, 0x543c01c0
+#define IOMUXC_PAD_GPIO_IO00__LPSPI6_PCS0                         0x543c0010, 0x4, 0x543c0000, 0x0, 0x543c01c0
+#define IOMUXC_PAD_GPIO_IO00__LPUART5_TX                          0x543c0010, 0x5, 0x543c0434, 0x1, 0x543c01c0
+#define IOMUXC_PAD_GPIO_IO00__LPI2C5_SDA                          0x543c0010, 0x6, 0x543c03ec, 0x0, 0x543c01c0
+#define IOMUXC_PAD_GPIO_IO00__FLEXIO1_FLEXIO00                    0x543c0010, 0x7, 0x543c036c, 0x0, 0x543c01c0
+#define IOMUXC_PAD_GPIO_IO01__GPIO2_IO01                          0x543c0014, 0x0, 0x543c0000, 0x0, 0x543c01c4
+#define IOMUXC_PAD_GPIO_IO01__LPI2C3_SCL                          0x543c0014, 0x1, 0x543c03e0, 0x0, 0x543c01c4
+#define IOMUXC_PAD_GPIO_IO01__MEDIAMIX_CAM_DATA00                 0x543c0014, 0x2, 0x543c0000, 0x0, 0x543c01c4
+#define IOMUXC_PAD_GPIO_IO01__MEDIAMIX_DISP_DE                    0x543c0014, 0x3, 0x543c0000, 0x0, 0x543c01c4
+#define IOMUXC_PAD_GPIO_IO01__LPSPI6_SIN                          0x543c0014, 0x4, 0x543c0000, 0x0, 0x543c01c4
+#define IOMUXC_PAD_GPIO_IO01__LPUART5_RX                          0x543c0014, 0x5, 0x543c0430, 0x1, 0x543c01c4
+#define IOMUXC_PAD_GPIO_IO01__LPI2C5_SCL                          0x543c0014, 0x6, 0x543c03e8, 0x0, 0x543c01c4
+#define IOMUXC_PAD_GPIO_IO01__FLEXIO1_FLEXIO01                    0x543c0014, 0x7, 0x543c0370, 0x0, 0x543c01c4
+#define IOMUXC_PAD_GPIO_IO02__GPIO2_IO02                          0x543c0018, 0x0, 0x543c0000, 0x0, 0x543c01c8
+#define IOMUXC_PAD_GPIO_IO02__LPI2C4_SDA                          0x543c0018, 0x1, 0x543c0000, 0x0, 0x543c01c8
+#define IOMUXC_PAD_GPIO_IO02__MEDIAMIX_CAM_VSYNC                  0x543c0018, 0x2, 0x543c0000, 0x0, 0x543c01c8
+#define IOMUXC_PAD_GPIO_IO02__MEDIAMIX_DISP_VSYNC                 0x543c0018, 0x3, 0x543c0000, 0x0, 0x543c01c8
+#define IOMUXC_PAD_GPIO_IO02__LPSPI6_SOUT                         0x543c0018, 0x4, 0x543c0000, 0x0, 0x543c01c8
+#define IOMUXC_PAD_GPIO_IO02__LPUART5_CTS_B                       0x543c0018, 0x5, 0x543c042c, 0x1, 0x543c01c8
+#define IOMUXC_PAD_GPIO_IO02__LPI2C6_SDA                          0x543c0018, 0x6, 0x543c03f4, 0x0, 0x543c01c8
+#define IOMUXC_PAD_GPIO_IO02__FLEXIO1_FLEXIO02                    0x543c0018, 0x7, 0x543c0374, 0x0, 0x543c01c8
+#define IOMUXC_PAD_GPIO_IO03__GPIO2_IO03                          0x543c001c, 0x0, 0x543c0000, 0x0, 0x543c01cc
+#define IOMUXC_PAD_GPIO_IO03__LPI2C4_SCL                          0x543c001c, 0x1, 0x543c0000, 0x0, 0x543c01cc
+#define IOMUXC_PAD_GPIO_IO03__MEDIAMIX_CAM_HSYNC                  0x543c001c, 0x2, 0x543c0000, 0x0, 0x543c01cc
+#define IOMUXC_PAD_GPIO_IO03__MEDIAMIX_DISP_HSYNC                 0x543c001c, 0x3, 0x543c0000, 0x0, 0x543c01cc
+#define IOMUXC_PAD_GPIO_IO03__LPSPI6_SCK                          0x543c001c, 0x4, 0x543c0000, 0x0, 0x543c01cc
+#define IOMUXC_PAD_GPIO_IO03__LPUART5_RTS_B                       0x543c001c, 0x5, 0x543c0000, 0x0, 0x543c01cc
+#define IOMUXC_PAD_GPIO_IO03__LPI2C6_SCL                          0x543c001c, 0x6, 0x543c03f0, 0x0, 0x543c01cc
+#define IOMUXC_PAD_GPIO_IO03__FLEXIO1_FLEXIO03                    0x543c001c, 0x7, 0x543c0378, 0x0, 0x543c01cc
+#define IOMUXC_PAD_GPIO_IO04__GPIO2_IO04                          0x543c0020, 0x0, 0x543c0000, 0x0, 0x543c01d0
+#define IOMUXC_PAD_GPIO_IO04__TPM3_CH0                            0x543c0020, 0x1, 0x543c0000, 0x0, 0x543c01d0
+#define IOMUXC_PAD_GPIO_IO04__PDM_CLK                             0x543c0020, 0x2, 0x543c0000, 0x0, 0x543c01d0
+#define IOMUXC_PAD_GPIO_IO04__MEDIAMIX_DISP_DATA00                0x543c0020, 0x3, 0x543c0000, 0x0, 0x543c01d0
+#define IOMUXC_PAD_GPIO_IO04__LPSPI7_PCS0                         0x543c0020, 0x4, 0x543c0000, 0x0, 0x543c01d0
+#define IOMUXC_PAD_GPIO_IO04__LPUART6_TX                          0x543c0020, 0x5, 0x543c0000, 0x0, 0x543c01d0
+#define IOMUXC_PAD_GPIO_IO04__LPI2C6_SDA                          0x543c0020, 0x6, 0x543c03f4, 0x1, 0x543c01d0
+#define IOMUXC_PAD_GPIO_IO04__FLEXIO1_FLEXIO04                    0x543c0020, 0x7, 0x543c037c, 0x0, 0x543c01d0
+#define IOMUXC_PAD_GPIO_IO05__GPIO2_IO05                          0x543c0024, 0x0, 0x543c0000, 0x0, 0x543c01d4
+#define IOMUXC_PAD_GPIO_IO05__TPM4_CH0                            0x543c0024, 0x1, 0x543c0000, 0x0, 0x543c01d4
+#define IOMUXC_PAD_GPIO_IO05__PDM_BIT_STREAM00                    0x543c0024, 0x2, 0x543c0438, 0x0, 0x543c01d4
+#define IOMUXC_PAD_GPIO_IO05__MEDIAMIX_DISP_DATA01                0x543c0024, 0x3, 0x543c0000, 0x0, 0x543c01d4
+#define IOMUXC_PAD_GPIO_IO05__LPSPI7_SIN                          0x543c0024, 0x4, 0x543c0000, 0x0, 0x543c01d4
+#define IOMUXC_PAD_GPIO_IO05__LPUART6_RX                          0x543c0024, 0x5, 0x543c0000, 0x0, 0x543c01d4
+#define IOMUXC_PAD_GPIO_IO05__LPI2C6_SCL                          0x543c0024, 0x6, 0x543c03f0, 0x1, 0x543c01d4
+#define IOMUXC_PAD_GPIO_IO05__FLEXIO1_FLEXIO05                    0x543c0024, 0x7, 0x543c0380, 0x0, 0x543c01d4
+#define IOMUXC_PAD_GPIO_IO06__GPIO2_IO06                          0x543c0028, 0x0, 0x543c0000, 0x0, 0x543c01d8
+#define IOMUXC_PAD_GPIO_IO06__TPM5_CH0                            0x543c0028, 0x1, 0x543c0000, 0x0, 0x543c01d8
+#define IOMUXC_PAD_GPIO_IO06__PDM_BIT_STREAM01                    0x543c0028, 0x2, 0x543c043c, 0x0, 0x543c01d8
+#define IOMUXC_PAD_GPIO_IO06__MEDIAMIX_DISP_DATA02                0x543c0028, 0x3, 0x543c0000, 0x0, 0x543c01d8
+#define IOMUXC_PAD_GPIO_IO06__LPSPI7_SOUT                         0x543c0028, 0x4, 0x543c0000, 0x0, 0x543c01d8
+#define IOMUXC_PAD_GPIO_IO06__LPUART6_CTS_B                       0x543c0028, 0x5, 0x543c0000, 0x0, 0x543c01d8
+#define IOMUXC_PAD_GPIO_IO06__LPI2C7_SDA                          0x543c0028, 0x6, 0x543c03fc, 0x0, 0x543c01d8
+#define IOMUXC_PAD_GPIO_IO06__FLEXIO1_FLEXIO06                    0x543c0028, 0x7, 0x543c0384, 0x0, 0x543c01d8
+#define IOMUXC_PAD_GPIO_IO07__GPIO2_IO07                          0x543c002c, 0x0, 0x543c0000, 0x0, 0x543c01dc
+#define IOMUXC_PAD_GPIO_IO07__LPSPI3_PCS1                         0x543c002c, 0x1, 0x543c0000, 0x0, 0x543c01dc
+#define IOMUXC_PAD_GPIO_IO07__MEDIAMIX_CAM_DATA01                 0x543c002c, 0x2, 0x543c0000, 0x0, 0x543c01dc
+#define IOMUXC_PAD_GPIO_IO07__MEDIAMIX_DISP_DATA03                0x543c002c, 0x3, 0x543c0000, 0x0, 0x543c01dc
+#define IOMUXC_PAD_GPIO_IO07__LPSPI7_SCK                          0x543c002c, 0x4, 0x543c0000, 0x0, 0x543c01dc
+#define IOMUXC_PAD_GPIO_IO07__LPUART6_RTS_B                       0x543c002c, 0x5, 0x543c0000, 0x0, 0x543c01dc
+#define IOMUXC_PAD_GPIO_IO07__LPI2C7_SCL                          0x543c002c, 0x6, 0x543c03f8, 0x0, 0x543c01dc
+#define IOMUXC_PAD_GPIO_IO07__FLEXIO1_FLEXIO07                    0x543c002c, 0x7, 0x543c0388, 0x0, 0x543c01dc
+#define IOMUXC_PAD_GPIO_IO08__GPIO2_IO08                          0x543c0030, 0x0, 0x543c0000, 0x0, 0x543c01e0
+#define IOMUXC_PAD_GPIO_IO08__LPSPI3_PCS0                         0x543c0030, 0x1, 0x543c0000, 0x0, 0x543c01e0
+#define IOMUXC_PAD_GPIO_IO08__MEDIAMIX_CAM_DATA02                 0x543c0030, 0x2, 0x543c0000, 0x0, 0x543c01e0
+#define IOMUXC_PAD_GPIO_IO08__MEDIAMIX_DISP_DATA04                0x543c0030, 0x3, 0x543c0000, 0x0, 0x543c01e0
+#define IOMUXC_PAD_GPIO_IO08__TPM6_CH0                            0x543c0030, 0x4, 0x543c0000, 0x0, 0x543c01e0
+#define IOMUXC_PAD_GPIO_IO08__LPUART7_TX                          0x543c0030, 0x5, 0x543c0000, 0x0, 0x543c01e0
+#define IOMUXC_PAD_GPIO_IO08__LPI2C7_SDA                          0x543c0030, 0x6, 0x543c03fc, 0x1, 0x543c01e0
+#define IOMUXC_PAD_GPIO_IO08__FLEXIO1_FLEXIO08                    0x543c0030, 0x7, 0x543c038c, 0x0, 0x543c01e0
+#define IOMUXC_PAD_GPIO_IO09__GPIO2_IO09                          0x543c0034, 0x0, 0x543c0000, 0x0, 0x543c01e4
+#define IOMUXC_PAD_GPIO_IO09__LPSPI3_SIN                          0x543c0034, 0x1, 0x543c0000, 0x0, 0x543c01e4
+#define IOMUXC_PAD_GPIO_IO09__MEDIAMIX_CAM_DATA03                 0x543c0034, 0x2, 0x543c0000, 0x0, 0x543c01e4
+#define IOMUXC_PAD_GPIO_IO09__MEDIAMIX_DISP_DATA05                0x543c0034, 0x3, 0x543c0000, 0x0, 0x543c01e4
+#define IOMUXC_PAD_GPIO_IO09__TPM3_EXTCLK                         0x543c0034, 0x4, 0x543c0000, 0x0, 0x543c01e4
+#define IOMUXC_PAD_GPIO_IO09__LPUART7_RX                          0x543c0034, 0x5, 0x543c0000, 0x0, 0x543c01e4
+#define IOMUXC_PAD_GPIO_IO09__LPI2C7_SCL                          0x543c0034, 0x6, 0x543c03f8, 0x1, 0x543c01e4
+#define IOMUXC_PAD_GPIO_IO09__FLEXIO1_FLEXIO09                    0x543c0034, 0x7, 0x543c0390, 0x0, 0x543c01e4
+#define IOMUXC_PAD_GPIO_IO10__GPIO2_IO10                          0x543c0038, 0x0, 0x543c0000, 0x0, 0x543c01e8
+#define IOMUXC_PAD_GPIO_IO10__LPSPI3_SOUT                         0x543c0038, 0x1, 0x543c0000, 0x0, 0x543c01e8
+#define IOMUXC_PAD_GPIO_IO10__MEDIAMIX_CAM_DATA04                 0x543c0038, 0x2, 0x543c0000, 0x0, 0x543c01e8
+#define IOMUXC_PAD_GPIO_IO10__MEDIAMIX_DISP_DATA06                0x543c0038, 0x3, 0x543c0000, 0x0, 0x543c01e8
+#define IOMUXC_PAD_GPIO_IO10__TPM4_EXTCLK                         0x543c0038, 0x4, 0x543c0000, 0x0, 0x543c01e8
+#define IOMUXC_PAD_GPIO_IO10__LPUART7_CTS_B                       0x543c0038, 0x5, 0x543c0000, 0x0, 0x543c01e8
+#define IOMUXC_PAD_GPIO_IO10__LPI2C8_SDA                          0x543c0038, 0x6, 0x543c0404, 0x0, 0x543c01e8
+#define IOMUXC_PAD_GPIO_IO10__FLEXIO1_FLEXIO10                    0x543c0038, 0x7, 0x543c0394, 0x0, 0x543c01e8
+#define IOMUXC_PAD_GPIO_IO11__GPIO2_IO11                          0x543c003c, 0x0, 0x543c0000, 0x0, 0x543c01ec
+#define IOMUXC_PAD_GPIO_IO11__LPSPI3_SCK                          0x543c003c, 0x1, 0x543c0000, 0x0, 0x543c01ec
+#define IOMUXC_PAD_GPIO_IO11__MEDIAMIX_CAM_DATA05                 0x543c003c, 0x2, 0x543c0000, 0x0, 0x543c01ec
+#define IOMUXC_PAD_GPIO_IO11__MEDIAMIX_DISP_DATA07                0x543c003c, 0x3, 0x543c0000, 0x0, 0x543c01ec
+#define IOMUXC_PAD_GPIO_IO11__TPM5_EXTCLK                         0x543c003c, 0x4, 0x543c0000, 0x0, 0x543c01ec
+#define IOMUXC_PAD_GPIO_IO11__LPUART7_RTS_B                       0x543c003c, 0x5, 0x543c0000, 0x0, 0x543c01ec
+#define IOMUXC_PAD_GPIO_IO11__LPI2C8_SCL                          0x543c003c, 0x6, 0x543c0400, 0x0, 0x543c01ec
+#define IOMUXC_PAD_GPIO_IO11__FLEXIO1_FLEXIO11                    0x543c003c, 0x7, 0x543c0398, 0x0, 0x543c01ec
+#define IOMUXC_PAD_GPIO_IO12__GPIO2_IO12                          0x543c0040, 0x0, 0x543c0000, 0x0, 0x543c01f0
+#define IOMUXC_PAD_GPIO_IO12__TPM3_CH2                            0x543c0040, 0x1, 0x543c0000, 0x0, 0x543c01f0
+#define IOMUXC_PAD_GPIO_IO12__PDM_BIT_STREAM02                    0x543c0040, 0x2, 0x543c0440, 0x0, 0x543c01f0
+#define IOMUXC_PAD_GPIO_IO12__MEDIAMIX_DISP_DATA08                0x543c0040, 0x3, 0x543c0000, 0x0, 0x543c01f0
+#define IOMUXC_PAD_GPIO_IO12__LPSPI8_PCS0                         0x543c0040, 0x4, 0x543c0000, 0x0, 0x543c01f0
+#define IOMUXC_PAD_GPIO_IO12__LPUART8_TX                          0x543c0040, 0x5, 0x543c0000, 0x0, 0x543c01f0
+#define IOMUXC_PAD_GPIO_IO12__LPI2C8_SDA                          0x543c0040, 0x6, 0x543c0404, 0x1, 0x543c01f0
+#define IOMUXC_PAD_GPIO_IO12__SAI3_RX_SYNC                        0x543c0040, 0x7, 0x543c0450, 0x0, 0x543c01f0
+#define IOMUXC_PAD_GPIO_IO13__GPIO2_IO13                          0x543c0044, 0x0, 0x543c0000, 0x0, 0x543c01f4
+#define IOMUXC_PAD_GPIO_IO13__TPM4_CH2                            0x543c0044, 0x1, 0x543c0000, 0x0, 0x543c01f4
+#define IOMUXC_PAD_GPIO_IO13__PDM_BIT_STREAM03                    0x543c0044, 0x2, 0x543c0444, 0x0, 0x543c01f4
+#define IOMUXC_PAD_GPIO_IO13__MEDIAMIX_DISP_DATA09                0x543c0044, 0x3, 0x543c0000, 0x0, 0x543c01f4
+#define IOMUXC_PAD_GPIO_IO13__LPSPI8_SIN                          0x543c0044, 0x4, 0x543c0000, 0x0, 0x543c01f4
+#define IOMUXC_PAD_GPIO_IO13__LPUART8_RX                          0x543c0044, 0x5, 0x543c0000, 0x0, 0x543c01f4
+#define IOMUXC_PAD_GPIO_IO13__LPI2C8_SCL                          0x543c0044, 0x6, 0x543c0400, 0x1, 0x543c01f4
+#define IOMUXC_PAD_GPIO_IO13__FLEXIO1_FLEXIO13                    0x543c0044, 0x7, 0x543c039c, 0x0, 0x543c01f4
+#define IOMUXC_PAD_GPIO_IO14__GPIO2_IO14                          0x543c0048, 0x0, 0x543c0000, 0x0, 0x543c01f8
+#define IOMUXC_PAD_GPIO_IO14__LPUART3_TX                          0x543c0048, 0x1, 0x543c041c, 0x0, 0x543c01f8
+#define IOMUXC_PAD_GPIO_IO14__MEDIAMIX_CAM_DATA06                 0x543c0048, 0x2, 0x543c0000, 0x0, 0x543c01f8
+#define IOMUXC_PAD_GPIO_IO14__MEDIAMIX_DISP_DATA10                0x543c0048, 0x3, 0x543c0000, 0x0, 0x543c01f8
+#define IOMUXC_PAD_GPIO_IO14__LPSPI8_SOUT                         0x543c0048, 0x4, 0x543c0000, 0x0, 0x543c01f8
+#define IOMUXC_PAD_GPIO_IO14__LPUART8_CTS_B                       0x543c0048, 0x5, 0x543c0000, 0x0, 0x543c01f8
+#define IOMUXC_PAD_GPIO_IO14__LPUART4_TX                          0x543c0048, 0x6, 0x543c0428, 0x0, 0x543c01f8
+#define IOMUXC_PAD_GPIO_IO14__FLEXIO1_FLEXIO14                    0x543c0048, 0x7, 0x543c03a0, 0x0, 0x543c01f8
+#define IOMUXC_PAD_GPIO_IO15__GPIO2_IO15                          0x543c004c, 0x0, 0x543c0000, 0x0, 0x543c01fc
+#define IOMUXC_PAD_GPIO_IO15__LPUART3_RX                          0x543c004c, 0x1, 0x543c0418, 0x0, 0x543c01fc
+#define IOMUXC_PAD_GPIO_IO15__MEDIAMIX_CAM_DATA07                 0x543c004c, 0x2, 0x543c0000, 0x0, 0x543c01fc
+#define IOMUXC_PAD_GPIO_IO15__MEDIAMIX_DISP_DATA11                0x543c004c, 0x3, 0x543c0000, 0x0, 0x543c01fc
+#define IOMUXC_PAD_GPIO_IO15__LPSPI8_SCK                          0x543c004c, 0x4, 0x543c0000, 0x0, 0x543c01fc
+#define IOMUXC_PAD_GPIO_IO15__LPUART8_RTS_B                       0x543c004c, 0x5, 0x543c0000, 0x0, 0x543c01fc
+#define IOMUXC_PAD_GPIO_IO15__LPUART4_RX                          0x543c004c, 0x6, 0x543c0424, 0x0, 0x543c01fc
+#define IOMUXC_PAD_GPIO_IO15__FLEXIO1_FLEXIO15                    0x543c004c, 0x7, 0x543c03a4, 0x0, 0x543c01fc
+#define IOMUXC_PAD_GPIO_IO16__GPIO2_IO16                          0x543c0050, 0x0, 0x543c0000, 0x0, 0x543c0200
+#define IOMUXC_PAD_GPIO_IO16__SAI3_TX_BCLK                        0x543c0050, 0x1, 0x543c0000, 0x0, 0x543c0200
+#define IOMUXC_PAD_GPIO_IO16__PDM_BIT_STREAM02                    0x543c0050, 0x2, 0x543c0440, 0x1, 0x543c0200
+#define IOMUXC_PAD_GPIO_IO16__MEDIAMIX_DISP_DATA12                0x543c0050, 0x3, 0x543c0000, 0x0, 0x543c0200
+#define IOMUXC_PAD_GPIO_IO16__LPUART3_CTS_B                       0x543c0050, 0x4, 0x543c0414, 0x0, 0x543c0200
+#define IOMUXC_PAD_GPIO_IO16__LPSPI4_PCS2                         0x543c0050, 0x5, 0x543c0000, 0x0, 0x543c0200
+#define IOMUXC_PAD_GPIO_IO16__LPUART4_CTS_B                       0x543c0050, 0x6, 0x543c0420, 0x0, 0x543c0200
+#define IOMUXC_PAD_GPIO_IO16__FLEXIO1_FLEXIO16                    0x543c0050, 0x7, 0x543c03a8, 0x0, 0x543c0200
+#define IOMUXC_PAD_GPIO_IO17__GPIO2_IO17                          0x543c0054, 0x0, 0x543c0000, 0x0, 0x543c0204
+#define IOMUXC_PAD_GPIO_IO17__SAI3_MCLK                           0x543c0054, 0x1, 0x543c0000, 0x0, 0x543c0204
+#define IOMUXC_PAD_GPIO_IO17__MEDIAMIX_CAM_DATA08                 0x543c0054, 0x2, 0x543c0000, 0x0, 0x543c0204
+#define IOMUXC_PAD_GPIO_IO17__MEDIAMIX_DISP_DATA13                0x543c0054, 0x3, 0x543c0000, 0x0, 0x543c0204
+#define IOMUXC_PAD_GPIO_IO17__LPUART3_RTS_B                       0x543c0054, 0x4, 0x543c0000, 0x0, 0x543c0204
+#define IOMUXC_PAD_GPIO_IO17__LPSPI4_PCS1                         0x543c0054, 0x5, 0x543c0000, 0x0, 0x543c0204
+#define IOMUXC_PAD_GPIO_IO17__LPUART4_RTS_B                       0x543c0054, 0x6, 0x543c0000, 0x0, 0x543c0204
+#define IOMUXC_PAD_GPIO_IO17__FLEXIO1_FLEXIO17                    0x543c0054, 0x7, 0x543c03ac, 0x0, 0x543c0204
+#define IOMUXC_PAD_GPIO_IO18__GPIO2_IO18                          0x543c0058, 0x0, 0x543c0000, 0x0, 0x543c0208
+#define IOMUXC_PAD_GPIO_IO18__SAI3_RX_BCLK                        0x543c0058, 0x1, 0x543c044c, 0x0, 0x543c0208
+#define IOMUXC_PAD_GPIO_IO18__MEDIAMIX_CAM_DATA09                 0x543c0058, 0x2, 0x543c0000, 0x0, 0x543c0208
+#define IOMUXC_PAD_GPIO_IO18__MEDIAMIX_DISP_DATA14                0x543c0058, 0x3, 0x543c0000, 0x0, 0x543c0208
+#define IOMUXC_PAD_GPIO_IO18__LPSPI5_PCS0                         0x543c0058, 0x4, 0x543c0000, 0x0, 0x543c0208
+#define IOMUXC_PAD_GPIO_IO18__LPSPI4_PCS0                         0x543c0058, 0x5, 0x543c0000, 0x0, 0x543c0208
+#define IOMUXC_PAD_GPIO_IO18__TPM5_CH2                            0x543c0058, 0x6, 0x543c0000, 0x0, 0x543c0208
+#define IOMUXC_PAD_GPIO_IO18__FLEXIO1_FLEXIO18                    0x543c0058, 0x7, 0x543c03b0, 0x0, 0x543c0208
+#define IOMUXC_PAD_GPIO_IO19__GPIO2_IO19                          0x543c005c, 0x0, 0x543c0000, 0x0, 0x543c020c
+#define IOMUXC_PAD_GPIO_IO19__SAI3_RX_SYNC                        0x543c005c, 0x1, 0x543c0450, 0x1, 0x543c020c
+#define IOMUXC_PAD_GPIO_IO19__PDM_BIT_STREAM03                    0x543c005c, 0x2, 0x543c0444, 0x1, 0x543c020c
+#define IOMUXC_PAD_GPIO_IO19__MEDIAMIX_DISP_DATA15                0x543c005c, 0x3, 0x543c0000, 0x0, 0x543c020c
+#define IOMUXC_PAD_GPIO_IO19__LPSPI5_SIN                          0x543c005c, 0x4, 0x543c0000, 0x0, 0x543c020c
+#define IOMUXC_PAD_GPIO_IO19__LPSPI4_SIN                          0x543c005c, 0x5, 0x543c0000, 0x0, 0x543c020c
+#define IOMUXC_PAD_GPIO_IO19__TPM6_CH2                            0x543c005c, 0x6, 0x543c0000, 0x0, 0x543c020c
+#define IOMUXC_PAD_GPIO_IO19__SAI3_TX_DATA00                      0x543c005c, 0x7, 0x543c0000, 0x0, 0x543c020c
+#define IOMUXC_PAD_GPIO_IO20__GPIO2_IO20                          0x543c0060, 0x0, 0x543c0000, 0x0, 0x543c0210
+#define IOMUXC_PAD_GPIO_IO20__SAI3_RX_DATA00                      0x543c0060, 0x1, 0x543c0000, 0x0, 0x543c0210
+#define IOMUXC_PAD_GPIO_IO20__PDM_BIT_STREAM00                    0x543c0060, 0x2, 0x543c0438, 0x1, 0x543c0210
+#define IOMUXC_PAD_GPIO_IO20__MEDIAMIX_DISP_DATA16                0x543c0060, 0x3, 0x543c0000, 0x0, 0x543c0210
+#define IOMUXC_PAD_GPIO_IO20__LPSPI5_SOUT                         0x543c0060, 0x4, 0x543c0000, 0x0, 0x543c0210
+#define IOMUXC_PAD_GPIO_IO20__LPSPI4_SOUT                         0x543c0060, 0x5, 0x543c0000, 0x0, 0x543c0210
+#define IOMUXC_PAD_GPIO_IO20__TPM3_CH1                            0x543c0060, 0x6, 0x543c0000, 0x0, 0x543c0210
+#define IOMUXC_PAD_GPIO_IO20__FLEXIO1_FLEXIO20                    0x543c0060, 0x7, 0x543c03b4, 0x0, 0x543c0210
+#define IOMUXC_PAD_GPIO_IO21__GPIO2_IO21                          0x543c0064, 0x0, 0x543c0000, 0x0, 0x543c0214
+#define IOMUXC_PAD_GPIO_IO21__SAI3_TX_DATA00                      0x543c0064, 0x1, 0x543c0000, 0x0, 0x543c0214
+#define IOMUXC_PAD_GPIO_IO21__PDM_CLK                             0x543c0064, 0x2, 0x543c0000, 0x0, 0x543c0214
+#define IOMUXC_PAD_GPIO_IO21__MEDIAMIX_DISP_DATA17                0x543c0064, 0x3, 0x543c0000, 0x0, 0x543c0214
+#define IOMUXC_PAD_GPIO_IO21__LPSPI5_SCK                          0x543c0064, 0x4, 0x543c0000, 0x0, 0x543c0214
+#define IOMUXC_PAD_GPIO_IO21__LPSPI4_SCK                          0x543c0064, 0x5, 0x543c0000, 0x0, 0x543c0214
+#define IOMUXC_PAD_GPIO_IO21__TPM4_CH1                            0x543c0064, 0x6, 0x543c0000, 0x0, 0x543c0214
+#define IOMUXC_PAD_GPIO_IO21__SAI3_RX_BCLK                        0x543c0064, 0x7, 0x543c044c, 0x1, 0x543c0214
+#define IOMUXC_PAD_GPIO_IO22__GPIO2_IO22                          0x543c0068, 0x0, 0x543c0000, 0x0, 0x543c0218
+#define IOMUXC_PAD_GPIO_IO22__USDHC3_CLK                          0x543c0068, 0x1, 0x543c0458, 0x0, 0x543c0218
+#define IOMUXC_PAD_GPIO_IO22__SPDIF_IN                            0x543c0068, 0x2, 0x543c0454, 0x0, 0x543c0218
+#define IOMUXC_PAD_GPIO_IO22__MEDIAMIX_DISP_DATA18                0x543c0068, 0x3, 0x543c0000, 0x0, 0x543c0218
+#define IOMUXC_PAD_GPIO_IO22__TPM5_CH1                            0x543c0068, 0x4, 0x543c0000, 0x0, 0x543c0218
+#define IOMUXC_PAD_GPIO_IO22__TPM6_EXTCLK                         0x543c0068, 0x5, 0x543c0000, 0x0, 0x543c0218
+#define IOMUXC_PAD_GPIO_IO22__LPI2C5_SDA                          0x543c0068, 0x6, 0x543c03ec, 0x1, 0x543c0218
+#define IOMUXC_PAD_GPIO_IO22__FLEXIO1_FLEXIO22                    0x543c0068, 0x7, 0x543c03b8, 0x0, 0x543c0218
+#define IOMUXC_PAD_GPIO_IO23__GPIO2_IO23                          0x543c006c, 0x0, 0x543c0000, 0x0, 0x543c021c
+#define IOMUXC_PAD_GPIO_IO23__USDHC3_CMD                          0x543c006c, 0x1, 0x543c045c, 0x0, 0x543c021c
+#define IOMUXC_PAD_GPIO_IO23__SPDIF_OUT                           0x543c006c, 0x2, 0x543c0000, 0x0, 0x543c021c
+#define IOMUXC_PAD_GPIO_IO23__MEDIAMIX_DISP_DATA19                0x543c006c, 0x3, 0x543c0000, 0x0, 0x543c021c
+#define IOMUXC_PAD_GPIO_IO23__TPM6_CH1                            0x543c006c, 0x4, 0x543c0000, 0x0, 0x543c021c
+#define IOMUXC_PAD_GPIO_IO23__LPI2C5_SCL                          0x543c006c, 0x6, 0x543c03e8, 0x1, 0x543c021c
+#define IOMUXC_PAD_GPIO_IO23__FLEXIO1_FLEXIO23                    0x543c006c, 0x7, 0x543c03bc, 0x0, 0x543c021c
+#define IOMUXC_PAD_GPIO_IO24__GPIO2_IO24                          0x543c0070, 0x0, 0x543c0000, 0x0, 0x543c0220
+#define IOMUXC_PAD_GPIO_IO24__USDHC3_DATA0                        0x543c0070, 0x1, 0x543c0460, 0x0, 0x543c0220
+#define IOMUXC_PAD_GPIO_IO24__MEDIAMIX_DISP_DATA20                0x543c0070, 0x3, 0x543c0000, 0x0, 0x543c0220
+#define IOMUXC_PAD_GPIO_IO24__TPM3_CH3                            0x543c0070, 0x4, 0x543c0000, 0x0, 0x543c0220
+#define IOMUXC_PAD_GPIO_IO24__JTAG_MUX_TDO                        0x543c0070, 0x5, 0x543c0000, 0x0, 0x543c0220
+#define IOMUXC_PAD_GPIO_IO24__LPSPI6_PCS1                         0x543c0070, 0x6, 0x543c0000, 0x0, 0x543c0220
+#define IOMUXC_PAD_GPIO_IO24__FLEXIO1_FLEXIO24                    0x543c0070, 0x7, 0x543c03c0, 0x0, 0x543c0220
+#define IOMUXC_PAD_GPIO_IO25__GPIO2_IO25                          0x543c0074, 0x0, 0x543c0000, 0x0, 0x543c0224
+#define IOMUXC_PAD_GPIO_IO25__USDHC3_DATA1                        0x543c0074, 0x1, 0x543c0464, 0x0, 0x543c0224
+#define IOMUXC_PAD_GPIO_IO25__CAN2_TX                             0x543c0074, 0x2, 0x543c0000, 0x0, 0x543c0224
+#define IOMUXC_PAD_GPIO_IO25__MEDIAMIX_DISP_DATA21                0x543c0074, 0x3, 0x543c0000, 0x0, 0x543c0224
+#define IOMUXC_PAD_GPIO_IO25__TPM4_CH3                            0x543c0074, 0x4, 0x543c0000, 0x0, 0x543c0224
+#define IOMUXC_PAD_GPIO_IO25__JTAG_MUX_TCK                        0x543c0074, 0x5, 0x543c03d4, 0x1, 0x543c0224
+#define IOMUXC_PAD_GPIO_IO25__LPSPI7_PCS1                         0x543c0074, 0x6, 0x543c0000, 0x0, 0x543c0224
+#define IOMUXC_PAD_GPIO_IO25__FLEXIO1_FLEXIO25                    0x543c0074, 0x7, 0x543c03c4, 0x0, 0x543c0224
+#define IOMUXC_PAD_GPIO_IO26__GPIO2_IO26                          0x543c0078, 0x0, 0x543c0000, 0x0, 0x543c0228
+#define IOMUXC_PAD_GPIO_IO26__USDHC3_DATA2                        0x543c0078, 0x1, 0x543c0468, 0x0, 0x543c0228
+#define IOMUXC_PAD_GPIO_IO26__PDM_BIT_STREAM01                    0x543c0078, 0x2, 0x543c043c, 0x1, 0x543c0228
+#define IOMUXC_PAD_GPIO_IO26__MEDIAMIX_DISP_DATA22                0x543c0078, 0x3, 0x543c0000, 0x0, 0x543c0228
+#define IOMUXC_PAD_GPIO_IO26__TPM5_CH3                            0x543c0078, 0x4, 0x543c0000, 0x0, 0x543c0228
+#define IOMUXC_PAD_GPIO_IO26__JTAG_MUX_TDI                        0x543c0078, 0x5, 0x543c03d8, 0x1, 0x543c0228
+#define IOMUXC_PAD_GPIO_IO26__LPSPI8_PCS1                         0x543c0078, 0x6, 0x543c0000, 0x0, 0x543c0228
+#define IOMUXC_PAD_GPIO_IO26__SAI3_TX_SYNC                        0x543c0078, 0x7, 0x543c0000, 0x0, 0x543c0228
+#define IOMUXC_PAD_GPIO_IO27__GPIO2_IO27                          0x543c007c, 0x0, 0x543c0000, 0x0, 0x543c022c
+#define IOMUXC_PAD_GPIO_IO27__USDHC3_DATA3                        0x543c007c, 0x1, 0x543c046c, 0x0, 0x543c022c
+#define IOMUXC_PAD_GPIO_IO27__CAN2_RX                             0x543c007c, 0x2, 0x543c0364, 0x1, 0x543c022c
+#define IOMUXC_PAD_GPIO_IO27__MEDIAMIX_DISP_DATA23                0x543c007c, 0x3, 0x543c0000, 0x0, 0x543c022c
+#define IOMUXC_PAD_GPIO_IO27__TPM6_CH3                            0x543c007c, 0x4, 0x543c0000, 0x0, 0x543c022c
+#define IOMUXC_PAD_GPIO_IO27__JTAG_MUX_TMS                        0x543c007c, 0x5, 0x543c03dc, 0x1, 0x543c022c
+#define IOMUXC_PAD_GPIO_IO27__LPSPI5_PCS1                         0x543c007c, 0x6, 0x543c0000, 0x0, 0x543c022c
+#define IOMUXC_PAD_GPIO_IO27__FLEXIO1_FLEXIO27                    0x543c007c, 0x7, 0x543c03c8, 0x0, 0x543c022c
+#define IOMUXC_PAD_GPIO_IO28__GPIO2_IO28                          0x543c0080, 0x0, 0x543c0000, 0x0, 0x543c0230
+#define IOMUXC_PAD_GPIO_IO28__LPI2C3_SDA                          0x543c0080, 0x1, 0x543c03e4, 0x1, 0x543c0230
+#define IOMUXC_PAD_GPIO_IO28__FLEXIO1_FLEXIO28                    0x543c0080, 0x7, 0x543c0000, 0x0, 0x543c0230
+#define IOMUXC_PAD_GPIO_IO29__GPIO2_IO29                          0x543c0084, 0x0, 0x543c0000, 0x0, 0x543c0234
+#define IOMUXC_PAD_GPIO_IO29__LPI2C3_SCL                          0x543c0084, 0x1, 0x543c03e0, 0x1, 0x543c0234
+#define IOMUXC_PAD_GPIO_IO29__FLEXIO1_FLEXIO29                    0x543c0084, 0x7, 0x543c0000, 0x0, 0x543c0234
+#define IOMUXC_PAD_CCM_CLKO1__CCMSRCGPCMIX_CLKO1                  0x543c0088, 0x0, 0x543c0000, 0x0, 0x543c0238
+#define IOMUXC_PAD_CCM_CLKO1__FLEXIO1_FLEXIO26                    0x543c0088, 0x4, 0x543c0000, 0x0, 0x543c0238
+#define IOMUXC_PAD_CCM_CLKO1__GPIO3_IO26                          0x543c0088, 0x5, 0x543c0000, 0x0, 0x543c0238
+#define IOMUXC_PAD_CCM_CLKO2__GPIO3_IO27                          0x543c008c, 0x5, 0x543c0000, 0x0, 0x543c023c
+#define IOMUXC_PAD_CCM_CLKO2__CCMSRCGPCMIX_CLKO2                  0x543c008c, 0x0, 0x543c0000, 0x0, 0x543c023c
+#define IOMUXC_PAD_CCM_CLKO2__FLEXIO1_FLEXIO27                    0x543c008c, 0x4, 0x543c03c8, 0x1, 0x543c023c
+#define IOMUXC_PAD_CCM_CLKO3__CCMSRCGPCMIX_CLKO3                  0x543c0090, 0x0, 0x543c0000, 0x0, 0x543c0240
+#define IOMUXC_PAD_CCM_CLKO3__FLEXIO2_FLEXIO28                    0x543c0090, 0x4, 0x543c0000, 0x0, 0x543c0240
+#define IOMUXC_PAD_CCM_CLKO3__GPIO4_IO28                          0x543c0090, 0x5, 0x543c0000, 0x0, 0x543c0240
+#define IOMUXC_PAD_CCM_CLKO4__CCMSRCGPCMIX_CLKO4                  0x543c0094, 0x0, 0x543c0000, 0x0, 0x543c0244
+#define IOMUXC_PAD_CCM_CLKO4__FLEXIO2_FLEXIO29                    0x543c0094, 0x4, 0x543c0000, 0x0, 0x543c0244
+#define IOMUXC_PAD_CCM_CLKO4__GPIO4_IO29                          0x543c0094, 0x5, 0x543c0000, 0x0, 0x543c0244
+#define IOMUXC_PAD_ENET1_MDC__ENET_QOS_MDC                        0x543c0098, 0x0, 0x543c0000, 0x0, 0x543c0248
+#define IOMUXC_PAD_ENET1_MDC__LPUART3_DCB_B                       0x543c0098, 0x1, 0x543c0000, 0x0, 0x543c0248
+#define IOMUXC_PAD_ENET1_MDC__I3C2_SCL                            0x543c0098, 0x2, 0x543c03cc, 0x0, 0x543c0248
+#define IOMUXC_PAD_ENET1_MDC__HSIOMIX_OTG_ID1                     0x543c0098, 0x3, 0x543c0000, 0x0, 0x543c0248
+#define IOMUXC_PAD_ENET1_MDC__FLEXIO2_FLEXIO00                    0x543c0098, 0x4, 0x543c0000, 0x0, 0x543c0248
+#define IOMUXC_PAD_ENET1_MDC__GPIO4_IO00                          0x543c0098, 0x5, 0x543c0000, 0x0, 0x543c0248
+#define IOMUXC_PAD_ENET1_MDIO__ENET_QOS_MDIO                      0x543c009c, 0x0, 0x543c0000, 0x0, 0x543c024c
+#define IOMUXC_PAD_ENET1_MDIO__LPUART3_RIN_B                      0x543c009c, 0x1, 0x543c0000, 0x0, 0x543c024c
+#define IOMUXC_PAD_ENET1_MDIO__I3C2_SDA                           0x543c009c, 0x2, 0x543c03d0, 0x0, 0x543c024c
+#define IOMUXC_PAD_ENET1_MDIO__HSIOMIX_OTG_PWR1                   0x543c009c, 0x3, 0x543c0000, 0x0, 0x543c024c
+#define IOMUXC_PAD_ENET1_MDIO__FLEXIO2_FLEXIO01                   0x543c009c, 0x4, 0x543c0000, 0x0, 0x543c024c
+#define IOMUXC_PAD_ENET1_MDIO__GPIO4_IO01                         0x543c009c, 0x5, 0x543c0000, 0x0, 0x543c024c
+#define IOMUXC_PAD_ENET1_TD3__ENET_QOS_RGMII_TD3                  0x543c00a0, 0x0, 0x543c0000, 0x0, 0x543c0250
+#define IOMUXC_PAD_ENET1_TD3__CAN2_TX                             0x543c00a0, 0x2, 0x543c0000, 0x0, 0x543c0250
+#define IOMUXC_PAD_ENET1_TD3__HSIOMIX_OTG_ID2                     0x543c00a0, 0x3, 0x543c0000, 0x0, 0x543c0250
+#define IOMUXC_PAD_ENET1_TD3__FLEXIO2_FLEXIO02                    0x543c00a0, 0x4, 0x543c0000, 0x0, 0x543c0250
+#define IOMUXC_PAD_ENET1_TD3__GPIO4_IO02                          0x543c00a0, 0x5, 0x543c0000, 0x0, 0x543c0250
+#define IOMUXC_PAD_ENET1_TD2__ENET_QOS_RGMII_TD2                  0x543c00a4, 0x0, 0x543c0000, 0x0, 0x543c0254
+#define IOMUXC_PAD_ENET1_TD2__CCM_ENET_QOS_CLOCK_GENERATE_REF_CLK 0x543c00a4, 0x1, 0x543c0000, 0x0, 0x543c0254
+#define IOMUXC_PAD_ENET1_TD2__CAN2_RX                             0x543c00a4, 0x2, 0x543c0364, 0x2, 0x543c0254
+#define IOMUXC_PAD_ENET1_TD2__HSIOMIX_OTG_OC2                     0x543c00a4, 0x3, 0x543c0000, 0x0, 0x543c0254
+#define IOMUXC_PAD_ENET1_TD2__FLEXIO2_FLEXIO03                    0x543c00a4, 0x4, 0x543c0000, 0x0, 0x543c0254
+#define IOMUXC_PAD_ENET1_TD2__GPIO4_IO03                          0x543c00a4, 0x5, 0x543c0000, 0x0, 0x543c0254
+#define IOMUXC_PAD_ENET1_TD1__ENET_QOS_RGMII_TD1                  0x543c00a8, 0x0, 0x543c0000, 0x0, 0x543c0258
+#define IOMUXC_PAD_ENET1_TD1__LPUART3_RTS_B                       0x543c00a8, 0x1, 0x543c0000, 0x0, 0x543c0258
+#define IOMUXC_PAD_ENET1_TD1__I3C2_PUR                            0x543c00a8, 0x2, 0x543c0000, 0x0, 0x543c0258
+#define IOMUXC_PAD_ENET1_TD1__HSIOMIX_OTG_OC1                     0x543c00a8, 0x3, 0x543c0000, 0x0, 0x543c0258
+#define IOMUXC_PAD_ENET1_TD1__FLEXIO2_FLEXIO04                    0x543c00a8, 0x4, 0x543c0000, 0x0, 0x543c0258
+#define IOMUXC_PAD_ENET1_TD1__GPIO4_IO04                          0x543c00a8, 0x5, 0x543c0000, 0x0, 0x543c0258
+#define IOMUXC_PAD_ENET1_TD1__I3C2_PUR_B                          0x543c00a8, 0x6, 0x543c0000, 0x0, 0x543c0258
+#define IOMUXC_PAD_ENET1_TD0__ENET_QOS_RGMII_TD0                  0x543c00ac, 0x0, 0x543c0000, 0x0, 0x543c025c
+#define IOMUXC_PAD_ENET1_TD0__LPUART3_TX                          0x543c00ac, 0x1, 0x543c041c, 0x1, 0x543c025c
+#define IOMUXC_PAD_ENET1_TD0__FLEXIO2_FLEXIO05                    0x543c00ac, 0x4, 0x543c0000, 0x0, 0x543c025c
+#define IOMUXC_PAD_ENET1_TD0__GPIO4_IO05                          0x543c00ac, 0x5, 0x543c0000, 0x0, 0x543c025c
+#define IOMUXC_PAD_ENET1_TX_CTL__ENET_QOS_RGMII_TX_CTL            0x543c00b0, 0x0, 0x543c0000, 0x0, 0x543c0260
+#define IOMUXC_PAD_ENET1_TX_CTL__LPUART3_DTR_B                    0x543c00b0, 0x1, 0x543c0000, 0x0, 0x543c0260
+#define IOMUXC_PAD_ENET1_TX_CTL__FLEXIO2_FLEXIO06                 0x543c00b0, 0x4, 0x543c0000, 0x0, 0x543c0260
+#define IOMUXC_PAD_ENET1_TX_CTL__GPIO4_IO06                       0x543c00b0, 0x5, 0x543c0000, 0x0, 0x543c0260
+#define IOMUXC_PAD_ENET1_TXC__CCM_ENET_QOS_CLOCK_GENERATE_TX_CLK  0x543c00b4, 0x0, 0x543c0000, 0x0, 0x543c0264
+#define IOMUXC_PAD_ENET1_TXC__ENET_QOS_TX_ER                      0x543c00b4, 0x1, 0x543c0000, 0x0, 0x543c0264
+#define IOMUXC_PAD_ENET1_TXC__FLEXIO2_FLEXIO07                    0x543c00b4, 0x4, 0x543c0000, 0x0, 0x543c0264
+#define IOMUXC_PAD_ENET1_TXC__GPIO4_IO07                          0x543c00b4, 0x5, 0x543c0000, 0x0, 0x543c0264
+#define IOMUXC_PAD_ENET1_RX_CTL__ENET_QOS_RGMII_RX_CTL            0x543c00b8, 0x0, 0x543c0000, 0x0, 0x543c0268
+#define IOMUXC_PAD_ENET1_RX_CTL__LPUART3_DSR_B                    0x543c00b8, 0x1, 0x543c0000, 0x0, 0x543c0268
+#define IOMUXC_PAD_ENET1_RX_CTL__HSIOMIX_OTG_PWR2                 0x543c00b8, 0x3, 0x543c0000, 0x0, 0x543c0268
+#define IOMUXC_PAD_ENET1_RX_CTL__FLEXIO2_FLEXIO08                 0x543c00b8, 0x4, 0x543c0000, 0x0, 0x543c0268
+#define IOMUXC_PAD_ENET1_RX_CTL__GPIO4_IO08                       0x543c00b8, 0x5, 0x543c0000, 0x0, 0x543c0268
+#define IOMUXC_PAD_ENET1_RXC__CCM_ENET_QOS_CLOCK_GENERATE_RX_CLK  0x543c00bc, 0x0, 0x543c0000, 0x0, 0x543c026c
+#define IOMUXC_PAD_ENET1_RXC__ENET_QOS_RX_ER                      0x543c00bc, 0x1, 0x543c0000, 0x0, 0x543c026c
+#define IOMUXC_PAD_ENET1_RXC__FLEXIO2_FLEXIO09                    0x543c00bc, 0x4, 0x543c0000, 0x0, 0x543c026c
+#define IOMUXC_PAD_ENET1_RXC__GPIO4_IO09                          0x543c00bc, 0x5, 0x543c0000, 0x0, 0x543c026c
+#define IOMUXC_PAD_ENET1_RD0__ENET_QOS_RGMII_RD0                  0x543c00c0, 0x0, 0x543c0000, 0x0, 0x543c0270
+#define IOMUXC_PAD_ENET1_RD0__LPUART3_RX                          0x543c00c0, 0x1, 0x543c0418, 0x1, 0x543c0270
+#define IOMUXC_PAD_ENET1_RD0__FLEXIO2_FLEXIO10                    0x543c00c0, 0x4, 0x543c0000, 0x0, 0x543c0270
+#define IOMUXC_PAD_ENET1_RD0__GPIO4_IO10                          0x543c00c0, 0x5, 0x543c0000, 0x0, 0x543c0270
+#define IOMUXC_PAD_ENET1_RD1__ENET_QOS_RGMII_RD1                  0x543c00c4, 0x0, 0x543c0000, 0x0, 0x543c0274
+#define IOMUXC_PAD_ENET1_RD1__LPUART3_CTS_B                       0x543c00c4, 0x1, 0x543c0414, 0x1, 0x543c0274
+#define IOMUXC_PAD_ENET1_RD1__LPTMR2_ALT1                         0x543c00c4, 0x3, 0x543c0408, 0x0, 0x543c0274
+#define IOMUXC_PAD_ENET1_RD1__FLEXIO2_FLEXIO11                    0x543c00c4, 0x4, 0x543c0000, 0x0, 0x543c0274
+#define IOMUXC_PAD_ENET1_RD1__GPIO4_IO11                          0x543c00c4, 0x5, 0x543c0000, 0x0, 0x543c0274
+#define IOMUXC_PAD_ENET1_RD2__ENET_QOS_RGMII_RD2                  0x543c00c8, 0x0, 0x543c0000, 0x0, 0x543c0278
+#define IOMUXC_PAD_ENET1_RD2__LPTMR2_ALT2                         0x543c00c8, 0x3, 0x543c040c, 0x0, 0x543c0278
+#define IOMUXC_PAD_ENET1_RD2__FLEXIO2_FLEXIO12                    0x543c00c8, 0x4, 0x543c0000, 0x0, 0x543c0278
+#define IOMUXC_PAD_ENET1_RD2__GPIO4_IO12                          0x543c00c8, 0x5, 0x543c0000, 0x0, 0x543c0278
+#define IOMUXC_PAD_ENET1_RD3__ENET_QOS_RGMII_RD3                  0x543c00cc, 0x0, 0x543c0000, 0x0, 0x543c027c
+#define IOMUXC_PAD_ENET1_RD3__FLEXSPI1_TESTER_TRIGGER             0x543c00cc, 0x2, 0x543c0000, 0x0, 0x543c027c
+#define IOMUXC_PAD_ENET1_RD3__LPTMR2_ALT3                         0x543c00cc, 0x3, 0x543c0410, 0x0, 0x543c027c
+#define IOMUXC_PAD_ENET1_RD3__FLEXIO2_FLEXIO13                    0x543c00cc, 0x4, 0x543c0000, 0x0, 0x543c027c
+#define IOMUXC_PAD_ENET1_RD3__GPIO4_IO13                          0x543c00cc, 0x5, 0x543c0000, 0x0, 0x543c027c
+#define IOMUXC_PAD_ENET2_MDC__ENET1_MDC                           0x543c00d0, 0x0, 0x543c0000, 0x0, 0x543c0280
+#define IOMUXC_PAD_ENET2_MDC__LPUART4_DCB_B                       0x543c00d0, 0x1, 0x543c0000, 0x0, 0x543c0280
+#define IOMUXC_PAD_ENET2_MDC__SAI2_RX_SYNC                        0x543c00d0, 0x2, 0x543c0000, 0x0, 0x543c0280
+#define IOMUXC_PAD_ENET2_MDC__FLEXIO2_FLEXIO14                    0x543c00d0, 0x4, 0x543c0000, 0x0, 0x543c0280
+#define IOMUXC_PAD_ENET2_MDC__GPIO4_IO14                          0x543c00d0, 0x5, 0x543c0000, 0x0, 0x543c0280
+#define IOMUXC_PAD_ENET2_MDIO__ENET1_MDIO                         0x543c00d4, 0x0, 0x543c0000, 0x0, 0x543c0284
+#define IOMUXC_PAD_ENET2_MDIO__LPUART4_RIN_B                      0x543c00d4, 0x1, 0x543c0000, 0x0, 0x543c0284
+#define IOMUXC_PAD_ENET2_MDIO__SAI2_RX_BCLK                       0x543c00d4, 0x2, 0x543c0000, 0x0, 0x543c0284
+#define IOMUXC_PAD_ENET2_MDIO__FLEXIO2_FLEXIO15                   0x543c00d4, 0x4, 0x543c0000, 0x0, 0x543c0284
+#define IOMUXC_PAD_ENET2_MDIO__GPIO4_IO15                         0x543c00d4, 0x5, 0x543c0000, 0x0, 0x543c0284
+#define IOMUXC_PAD_ENET2_TD3__SAI2_RX_DATA00                      0x543c00d8, 0x2, 0x543c0000, 0x0, 0x543c0288
+#define IOMUXC_PAD_ENET2_TD3__FLEXIO2_FLEXIO16                    0x543c00d8, 0x4, 0x543c0000, 0x0, 0x543c0288
+#define IOMUXC_PAD_ENET2_TD3__GPIO4_IO16                          0x543c00d8, 0x5, 0x543c0000, 0x0, 0x543c0288
+#define IOMUXC_PAD_ENET2_TD3__ENET1_RGMII_TD3                     0x543c00d8, 0x0, 0x543c0000, 0x0, 0x543c0288
+#define IOMUXC_PAD_ENET2_TD2__ENET1_RGMII_TD2                     0x543c00dc, 0x0, 0x543c0000, 0x0, 0x543c028c
+#define IOMUXC_PAD_ENET2_TD2__ENET1_TX_CLK                        0x543c00dc, 0x1, 0x543c0000, 0x0, 0x543c028c
+#define IOMUXC_PAD_ENET2_TD2__SAI2_RX_DATA01                      0x543c00dc, 0x2, 0x543c0000, 0x0, 0x543c028c
+#define IOMUXC_PAD_ENET2_TD2__FLEXIO2_FLEXIO17                    0x543c00dc, 0x4, 0x543c0000, 0x0, 0x543c028c
+#define IOMUXC_PAD_ENET2_TD2__GPIO4_IO17                          0x543c00dc, 0x5, 0x543c0000, 0x0, 0x543c028c
+#define IOMUXC_PAD_ENET2_TD1__ENET1_RGMII_TD1                     0x543c00e0, 0x0, 0x543c0000, 0x0, 0x543c0290
+#define IOMUXC_PAD_ENET2_TD1__LPUART4_RTS_B                       0x543c00e0, 0x1, 0x543c0000, 0x0, 0x543c0290
+#define IOMUXC_PAD_ENET2_TD1__SAI2_RX_DATA02                      0x543c00e0, 0x2, 0x543c0000, 0x0, 0x543c0290
+#define IOMUXC_PAD_ENET2_TD1__FLEXIO2_FLEXIO18                    0x543c00e0, 0x4, 0x543c0000, 0x0, 0x543c0290
+#define IOMUXC_PAD_ENET2_TD1__GPIO4_IO18                          0x543c00e0, 0x5, 0x543c0000, 0x0, 0x543c0290
+#define IOMUXC_PAD_ENET2_TD0__ENET1_RGMII_TD0                     0x543c00e4, 0x0, 0x543c0000, 0x0, 0x543c0294
+#define IOMUXC_PAD_ENET2_TD0__LPUART4_TX                          0x543c00e4, 0x1, 0x543c0428, 0x1, 0x543c0294
+#define IOMUXC_PAD_ENET2_TD0__SAI2_RX_DATA03                      0x543c00e4, 0x2, 0x543c0000, 0x0, 0x543c0294
+#define IOMUXC_PAD_ENET2_TD0__FLEXIO2_FLEXIO19                    0x543c00e4, 0x4, 0x543c0000, 0x0, 0x543c0294
+#define IOMUXC_PAD_ENET2_TD0__GPIO4_IO19                          0x543c00e4, 0x5, 0x543c0000, 0x0, 0x543c0294
+#define IOMUXC_PAD_ENET2_TX_CTL__ENET1_RGMII_TX_CTL               0x543c00e8, 0x0, 0x543c0000, 0x0, 0x543c0298
+#define IOMUXC_PAD_ENET2_TX_CTL__LPUART4_DTR_B                    0x543c00e8, 0x1, 0x543c0000, 0x0, 0x543c0298
+#define IOMUXC_PAD_ENET2_TX_CTL__SAI2_TX_SYNC                     0x543c00e8, 0x2, 0x543c0000, 0x0, 0x543c0298
+#define IOMUXC_PAD_ENET2_TX_CTL__FLEXIO2_FLEXIO20                 0x543c00e8, 0x4, 0x543c0000, 0x0, 0x543c0298
+#define IOMUXC_PAD_ENET2_TX_CTL__GPIO4_IO20                       0x543c00e8, 0x5, 0x543c0000, 0x0, 0x543c0298
+#define IOMUXC_PAD_ENET2_TXC__ENET1_RGMII_TXC                     0x543c00ec, 0x0, 0x543c0000, 0x0, 0x543c029c
+#define IOMUXC_PAD_ENET2_TXC__ENET1_TX_ER                         0x543c00ec, 0x1, 0x543c0000, 0x0, 0x543c029c
+#define IOMUXC_PAD_ENET2_TXC__SAI2_TX_BCLK                        0x543c00ec, 0x2, 0x543c0000, 0x0, 0x543c029c
+#define IOMUXC_PAD_ENET2_TXC__FLEXIO2_FLEXIO21                    0x543c00ec, 0x4, 0x543c0000, 0x0, 0x543c029c
+#define IOMUXC_PAD_ENET2_TXC__GPIO4_IO21                          0x543c00ec, 0x5, 0x543c0000, 0x0, 0x543c029c
+#define IOMUXC_PAD_ENET2_RX_CTL__ENET1_RGMII_RX_CTL               0x543c00f0, 0x0, 0x543c0000, 0x0, 0x543c02a0
+#define IOMUXC_PAD_ENET2_RX_CTL__LPUART4_DSR_B                    0x543c00f0, 0x1, 0x543c0000, 0x0, 0x543c02a0
+#define IOMUXC_PAD_ENET2_RX_CTL__SAI2_TX_DATA00                   0x543c00f0, 0x2, 0x543c0000, 0x0, 0x543c02a0
+#define IOMUXC_PAD_ENET2_RX_CTL__FLEXIO2_FLEXIO22                 0x543c00f0, 0x4, 0x543c0000, 0x0, 0x543c02a0
+#define IOMUXC_PAD_ENET2_RX_CTL__GPIO4_IO22                       0x543c00f0, 0x5, 0x543c0000, 0x0, 0x543c02a0
+#define IOMUXC_PAD_ENET2_RXC__ENET1_RGMII_RXC                     0x543c00f4, 0x0, 0x543c0000, 0x0, 0x543c02a4
+#define IOMUXC_PAD_ENET2_RXC__ENET1_RX_ER                         0x543c00f4, 0x1, 0x543c0000, 0x0, 0x543c02a4
+#define IOMUXC_PAD_ENET2_RXC__SAI2_TX_DATA01                      0x543c00f4, 0x2, 0x543c0000, 0x0, 0x543c02a4
+#define IOMUXC_PAD_ENET2_RXC__FLEXIO2_FLEXIO23                    0x543c00f4, 0x4, 0x543c0000, 0x0, 0x543c02a4
+#define IOMUXC_PAD_ENET2_RXC__GPIO4_IO23                          0x543c00f4, 0x5, 0x543c0000, 0x0, 0x543c02a4
+#define IOMUXC_PAD_ENET2_RD0__ENET1_RGMII_RD0                     0x543c00f8, 0x0, 0x543c0000, 0x0, 0x543c02a8
+#define IOMUXC_PAD_ENET2_RD0__LPUART4_RX                          0x543c00f8, 0x1, 0x543c0424, 0x1, 0x543c02a8
+#define IOMUXC_PAD_ENET2_RD0__SAI2_TX_DATA02                      0x543c00f8, 0x2, 0x543c0000, 0x0, 0x543c02a8
+#define IOMUXC_PAD_ENET2_RD0__FLEXIO2_FLEXIO24                    0x543c00f8, 0x4, 0x543c0000, 0x0, 0x543c02a8
+#define IOMUXC_PAD_ENET2_RD0__GPIO4_IO24                          0x543c00f8, 0x5, 0x543c0000, 0x0, 0x543c02a8
+#define IOMUXC_PAD_ENET2_RD1__ENET1_RGMII_RD1                     0x543c00fc, 0x0, 0x543c0000, 0x0, 0x543c02ac
+#define IOMUXC_PAD_ENET2_RD1__SPDIF_IN                            0x543c00fc, 0x1, 0x543c0454, 0x1, 0x543c02ac
+#define IOMUXC_PAD_ENET2_RD1__SAI2_TX_DATA03                      0x543c00fc, 0x2, 0x543c0000, 0x0, 0x543c02ac
+#define IOMUXC_PAD_ENET2_RD1__FLEXIO2_FLEXIO25                    0x543c00fc, 0x4, 0x543c0000, 0x0, 0x543c02ac
+#define IOMUXC_PAD_ENET2_RD1__GPIO4_IO25                          0x543c00fc, 0x5, 0x543c0000, 0x0, 0x543c02ac
+#define IOMUXC_PAD_ENET2_RD2__ENET1_RGMII_RD2                     0x543c0100, 0x0, 0x543c0000, 0x0, 0x543c02b0
+#define IOMUXC_PAD_ENET2_RD2__LPUART4_CTS_B                       0x543c0100, 0x1, 0x543c0420, 0x1, 0x543c02b0
+#define IOMUXC_PAD_ENET2_RD2__SAI2_MCLK                           0x543c0100, 0x2, 0x543c0000, 0x0, 0x543c02b0
+#define IOMUXC_PAD_ENET2_RD2__MQS2_RIGHT                          0x543c0100, 0x3, 0x543c0000, 0x0, 0x543c02b0
+#define IOMUXC_PAD_ENET2_RD2__FLEXIO2_FLEXIO26                    0x543c0100, 0x4, 0x543c0000, 0x0, 0x543c02b0
+#define IOMUXC_PAD_ENET2_RD2__GPIO4_IO26                          0x543c0100, 0x5, 0x543c0000, 0x0, 0x543c02b0
+#define IOMUXC_PAD_ENET2_RD3__ENET1_RGMII_RD3                     0x543c0104, 0x0, 0x543c0000, 0x0, 0x543c02b4
+#define IOMUXC_PAD_ENET2_RD3__SPDIF_OUT                           0x543c0104, 0x1, 0x543c0000, 0x0, 0x543c02b4
+#define IOMUXC_PAD_ENET2_RD3__SPDIF_IN                            0x543c0104, 0x2, 0x543c0454, 0x2, 0x543c02b4
+#define IOMUXC_PAD_ENET2_RD3__MQS2_LEFT                           0x543c0104, 0x3, 0x543c0000, 0x0, 0x543c02b4
+#define IOMUXC_PAD_ENET2_RD3__FLEXIO2_FLEXIO27                    0x543c0104, 0x4, 0x543c0000, 0x0, 0x543c02b4
+#define IOMUXC_PAD_ENET2_RD3__GPIO4_IO27                          0x543c0104, 0x5, 0x543c0000, 0x0, 0x543c02b4
+#define IOMUXC_PAD_SD1_CLK__FLEXIO1_FLEXIO08                      0x543c0108, 0x4, 0x543c038c, 0x1, 0x543c02b8
+#define IOMUXC_PAD_SD1_CLK__GPIO3_IO08                            0x543c0108, 0x5, 0x543c0000, 0x0, 0x543c02b8
+#define IOMUXC_PAD_SD1_CLK__USDHC1_CLK                            0x543c0108, 0x0, 0x543c0000, 0x0, 0x543c02b8
+#define IOMUXC_PAD_SD1_CMD__USDHC1_CMD                            0x543c010c, 0x0, 0x543c0000, 0x0, 0x543c02bc
+#define IOMUXC_PAD_SD1_CMD__FLEXIO1_FLEXIO09                      0x543c010c, 0x4, 0x543c0390, 0x1, 0x543c02bc
+#define IOMUXC_PAD_SD1_CMD__GPIO3_IO09                            0x543c010c, 0x5, 0x543c0000, 0x0, 0x543c02bc
+#define IOMUXC_PAD_SD1_DATA0__USDHC1_DATA0                        0x543c0110, 0x0, 0x543c0000, 0x0, 0x543c02c0
+#define IOMUXC_PAD_SD1_DATA0__FLEXIO1_FLEXIO10                    0x543c0110, 0x4, 0x543c0394, 0x1, 0x543c02c0
+#define IOMUXC_PAD_SD1_DATA0__GPIO3_IO10                          0x543c0110, 0x5, 0x543c0000, 0x0, 0x543c02c0
+#define IOMUXC_PAD_SD1_DATA1__USDHC1_DATA1                        0x543c0114, 0x0, 0x543c0000, 0x0, 0x543c02c4
+#define IOMUXC_PAD_SD1_DATA1__FLEXIO1_FLEXIO11                    0x543c0114, 0x4, 0x543c0398, 0x1, 0x543c02c4
+#define IOMUXC_PAD_SD1_DATA1__GPIO3_IO11                          0x543c0114, 0x5, 0x543c0000, 0x0, 0x543c02c4
+#define IOMUXC_PAD_SD1_DATA1__CCMSRCGPCMIX_INT_BOOT               0x543c0114, 0x6, 0x543c0000, 0x0, 0x543c02c4
+#define IOMUXC_PAD_SD1_DATA2__USDHC1_DATA2                        0x543c0118, 0x0, 0x543c0000, 0x0, 0x543c02c8
+#define IOMUXC_PAD_SD1_DATA2__FLEXIO1_FLEXIO12                    0x543c0118, 0x4, 0x543c0000, 0x0, 0x543c02c8
+#define IOMUXC_PAD_SD1_DATA2__GPIO3_IO12                          0x543c0118, 0x5, 0x543c0000, 0x0, 0x543c02c8
+#define IOMUXC_PAD_SD1_DATA2__CCMSRCGPCMIX_PMIC_READY             0x543c0118, 0x6, 0x543c0000, 0x0, 0x543c02c8
+#define IOMUXC_PAD_SD1_DATA3__USDHC1_DATA3                        0x543c011c, 0x0, 0x543c0000, 0x0, 0x543c02cc
+#define IOMUXC_PAD_SD1_DATA3__FLEXSPI1_A_SS1_B                    0x543c011c, 0x1, 0x543c0000, 0x0, 0x543c02cc
+#define IOMUXC_PAD_SD1_DATA3__FLEXIO1_FLEXIO13                    0x543c011c, 0x4, 0x543c039c, 0x1, 0x543c02cc
+#define IOMUXC_PAD_SD1_DATA3__GPIO3_IO13                          0x543c011c, 0x5, 0x543c0000, 0x0, 0x543c02cc
+#define IOMUXC_PAD_SD1_DATA4__USDHC1_DATA4                        0x543c0120, 0x0, 0x543c0000, 0x0, 0x543c02d0
+#define IOMUXC_PAD_SD1_DATA4__FLEXSPI1_A_DATA04                   0x543c0120, 0x1, 0x543c0000, 0x0, 0x543c02d0
+#define IOMUXC_PAD_SD1_DATA4__FLEXIO1_FLEXIO14                    0x543c0120, 0x4, 0x543c03a0, 0x1, 0x543c02d0
+#define IOMUXC_PAD_SD1_DATA4__GPIO3_IO14                          0x543c0120, 0x5, 0x543c0000, 0x0, 0x543c02d0
+#define IOMUXC_PAD_SD1_DATA5__USDHC1_DATA5                        0x543c0124, 0x0, 0x543c0000, 0x0, 0x543c02d4
+#define IOMUXC_PAD_SD1_DATA5__FLEXSPI1_A_DATA05                   0x543c0124, 0x1, 0x543c0000, 0x0, 0x543c02d4
+#define IOMUXC_PAD_SD1_DATA5__USDHC1_RESET_B                      0x543c0124, 0x2, 0x543c0000, 0x0, 0x543c02d4
+#define IOMUXC_PAD_SD1_DATA5__FLEXIO1_FLEXIO15                    0x543c0124, 0x4, 0x543c03a4, 0x1, 0x543c02d4
+#define IOMUXC_PAD_SD1_DATA5__GPIO3_IO15                          0x543c0124, 0x5, 0x543c0000, 0x0, 0x543c02d4
+#define IOMUXC_PAD_SD1_DATA6__USDHC1_DATA6                        0x543c0128, 0x0, 0x543c0000, 0x0, 0x543c02d8
+#define IOMUXC_PAD_SD1_DATA6__FLEXSPI1_A_DATA06                   0x543c0128, 0x1, 0x543c0000, 0x0, 0x543c02d8
+#define IOMUXC_PAD_SD1_DATA6__USDHC1_CD_B                         0x543c0128, 0x2, 0x543c0000, 0x0, 0x543c02d8
+#define IOMUXC_PAD_SD1_DATA6__FLEXIO1_FLEXIO16                    0x543c0128, 0x4, 0x543c03a8, 0x1, 0x543c02d8
+#define IOMUXC_PAD_SD1_DATA6__GPIO3_IO16                          0x543c0128, 0x5, 0x543c0000, 0x0, 0x543c02d8
+#define IOMUXC_PAD_SD1_DATA7__USDHC1_DATA7                        0x543c012c, 0x0, 0x543c0000, 0x0, 0x543c02dc
+#define IOMUXC_PAD_SD1_DATA7__FLEXSPI1_A_DATA07                   0x543c012c, 0x1, 0x543c0000, 0x0, 0x543c02dc
+#define IOMUXC_PAD_SD1_DATA7__USDHC1_WP                           0x543c012c, 0x2, 0x543c0000, 0x0, 0x543c02dc
+#define IOMUXC_PAD_SD1_DATA7__FLEXIO1_FLEXIO17                    0x543c012c, 0x4, 0x543c03ac, 0x1, 0x543c02dc
+#define IOMUXC_PAD_SD1_DATA7__GPIO3_IO17                          0x543c012c, 0x5, 0x543c0000, 0x0, 0x543c02dc
+#define IOMUXC_PAD_SD1_STROBE__USDHC1_STROBE                      0x543c0130, 0x0, 0x543c0000, 0x0, 0x543c02e0
+#define IOMUXC_PAD_SD1_STROBE__FLEXSPI1_A_DQS                     0x543c0130, 0x1, 0x543c0000, 0x0, 0x543c02e0
+#define IOMUXC_PAD_SD1_STROBE__FLEXIO1_FLEXIO18                   0x543c0130, 0x4, 0x543c03b0, 0x1, 0x543c02e0
+#define IOMUXC_PAD_SD1_STROBE__GPIO3_IO18                         0x543c0130, 0x5, 0x543c0000, 0x0, 0x543c02e0
+#define IOMUXC_PAD_SD2_VSELECT__USDHC2_VSELECT                    0x543c0134, 0x0, 0x543c0000, 0x0, 0x543c02e4
+#define IOMUXC_PAD_SD2_VSELECT__USDHC2_WP                         0x543c0134, 0x1, 0x543c0000, 0x0, 0x543c02e4
+#define IOMUXC_PAD_SD2_VSELECT__LPTMR2_ALT3                       0x543c0134, 0x2, 0x543c0410, 0x1, 0x543c02e4
+#define IOMUXC_PAD_SD2_VSELECT__FLEXIO1_FLEXIO19                  0x543c0134, 0x4, 0x543c0000, 0x0, 0x543c02e4
+#define IOMUXC_PAD_SD2_VSELECT__GPIO3_IO19                        0x543c0134, 0x5, 0x543c0000, 0x0, 0x543c02e4
+#define IOMUXC_PAD_SD2_VSELECT__CCMSRCGPCMIX_EXT_CLK1             0x543c0134, 0x6, 0x543c0368, 0x0, 0x543c02e4
+#define IOMUXC_PAD_SD3_CLK__USDHC3_CLK                            0x543c0138, 0x0, 0x543c0458, 0x1, 0x543c02e8
+#define IOMUXC_PAD_SD3_CLK__FLEXSPI1_A_SCLK                       0x543c0138, 0x1, 0x543c0000, 0x0, 0x543c02e8
+#define IOMUXC_PAD_SD3_CLK__FLEXIO1_FLEXIO20                      0x543c0138, 0x4, 0x543c03b4, 0x1, 0x543c02e8
+#define IOMUXC_PAD_SD3_CLK__GPIO3_IO20                            0x543c0138, 0x5, 0x543c0000, 0x0, 0x543c02e8
+#define IOMUXC_PAD_SD3_CMD__USDHC3_CMD                            0x543c013c, 0x0, 0x543c045c, 0x1, 0x543c02ec
+#define IOMUXC_PAD_SD3_CMD__FLEXSPI1_A_SS0_B                      0x543c013c, 0x1, 0x543c0000, 0x0, 0x543c02ec
+#define IOMUXC_PAD_SD3_CMD__FLEXIO1_FLEXIO21                      0x543c013c, 0x4, 0x543c0000, 0x0, 0x543c02ec
+#define IOMUXC_PAD_SD3_CMD__GPIO3_IO21                            0x543c013c, 0x5, 0x543c0000, 0x0, 0x543c02ec
+#define IOMUXC_PAD_SD3_DATA0__USDHC3_DATA0                        0x543c0140, 0x0, 0x543c0460, 0x1, 0x543c02f0
+#define IOMUXC_PAD_SD3_DATA0__FLEXSPI1_A_DATA00                   0x543c0140, 0x1, 0x543c0000, 0x0, 0x543c02f0
+#define IOMUXC_PAD_SD3_DATA0__FLEXIO1_FLEXIO22                    0x543c0140, 0x4, 0x543c03b8, 0x1, 0x543c02f0
+#define IOMUXC_PAD_SD3_DATA0__GPIO3_IO22                          0x543c0140, 0x5, 0x543c0000, 0x0, 0x543c02f0
+#define IOMUXC_PAD_SD3_DATA1__USDHC3_DATA1                        0x543c0144, 0x0, 0x543c0464, 0x1, 0x543c02f4
+#define IOMUXC_PAD_SD3_DATA1__FLEXSPI1_A_DATA01                   0x543c0144, 0x1, 0x543c0000, 0x0, 0x543c02f4
+#define IOMUXC_PAD_SD3_DATA1__FLEXIO1_FLEXIO23                    0x543c0144, 0x4, 0x543c03bc, 0x1, 0x543c02f4
+#define IOMUXC_PAD_SD3_DATA1__GPIO3_IO23                          0x543c0144, 0x5, 0x543c0000, 0x0, 0x543c02f4
+#define IOMUXC_PAD_SD3_DATA2__USDHC3_DATA2                        0x543c0148, 0x0, 0x543c0468, 0x1, 0x543c02f8
+#define IOMUXC_PAD_SD3_DATA2__FLEXSPI1_A_DATA02                   0x543c0148, 0x1, 0x543c0000, 0x0, 0x543c02f8
+#define IOMUXC_PAD_SD3_DATA2__FLEXIO1_FLEXIO24                    0x543c0148, 0x4, 0x543c03c0, 0x1, 0x543c02f8
+#define IOMUXC_PAD_SD3_DATA2__GPIO3_IO24                          0x543c0148, 0x5, 0x543c0000, 0x0, 0x543c02f8
+#define IOMUXC_PAD_SD3_DATA3__USDHC3_DATA3                        0x543c014c, 0x0, 0x543c046c, 0x1, 0x543c02fc
+#define IOMUXC_PAD_SD3_DATA3__FLEXSPI1_A_DATA03                   0x543c014c, 0x1, 0x543c0000, 0x0, 0x543c02fc
+#define IOMUXC_PAD_SD3_DATA3__FLEXIO1_FLEXIO25                    0x543c014c, 0x4, 0x543c03c4, 0x1, 0x543c02fc
+#define IOMUXC_PAD_SD3_DATA3__GPIO3_IO25                          0x543c014c, 0x5, 0x543c0000, 0x0, 0x543c02fc
+#define IOMUXC_PAD_SD2_CD_B__USDHC2_CD_B                          0x543c0150, 0x0, 0x543c0000, 0x0, 0x543c0300
+#define IOMUXC_PAD_SD2_CD_B__ENET_QOS_1588_EVENT0_IN              0x543c0150, 0x1, 0x543c0000, 0x0, 0x543c0300
+#define IOMUXC_PAD_SD2_CD_B__I3C2_SCL                             0x543c0150, 0x2, 0x543c03cc, 0x1, 0x543c0300
+#define IOMUXC_PAD_SD2_CD_B__FLEXIO1_FLEXIO00                     0x543c0150, 0x4, 0x543c036c, 0x1, 0x543c0300
+#define IOMUXC_PAD_SD2_CD_B__GPIO3_IO00                           0x543c0150, 0x5, 0x543c0000, 0x0, 0x543c0300
+#define IOMUXC_PAD_SD2_CLK__USDHC2_CLK                            0x543c0154, 0x0, 0x543c0000, 0x0, 0x543c0304
+#define IOMUXC_PAD_SD2_CLK__ENET_QOS_1588_EVENT0_OUT              0x543c0154, 0x1, 0x543c0000, 0x0, 0x543c0304
+#define IOMUXC_PAD_SD2_CLK__I3C2_SDA                              0x543c0154, 0x2, 0x543c03d0, 0x1, 0x543c0304
+#define IOMUXC_PAD_SD2_CLK__FLEXIO1_FLEXIO01                      0x543c0154, 0x4, 0x543c0370, 0x1, 0x543c0304
+#define IOMUXC_PAD_SD2_CLK__GPIO3_IO01                            0x543c0154, 0x5, 0x543c0000, 0x0, 0x543c0304
+#define IOMUXC_PAD_SD2_CLK__CCMSRCGPCMIX_OBSERVE0                 0x543c0154, 0x6, 0x543c0000, 0x0, 0x543c0304
+#define IOMUXC_PAD_SD2_CMD__USDHC2_CMD                            0x543c0158, 0x0, 0x543c0000, 0x0, 0x543c0308
+#define IOMUXC_PAD_SD2_CMD__ENET1_1588_EVENT0_IN                  0x543c0158, 0x1, 0x543c0000, 0x0, 0x543c0308
+#define IOMUXC_PAD_SD2_CMD__I3C2_PUR                              0x543c0158, 0x2, 0x543c0000, 0x0, 0x543c0308
+#define IOMUXC_PAD_SD2_CMD__I3C2_PUR_B                            0x543c0158, 0x3, 0x543c0000, 0x0, 0x543c0308
+#define IOMUXC_PAD_SD2_CMD__FLEXIO1_FLEXIO02                      0x543c0158, 0x4, 0x543c0374, 0x1, 0x543c0308
+#define IOMUXC_PAD_SD2_CMD__GPIO3_IO02                            0x543c0158, 0x5, 0x543c0000, 0x0, 0x543c0308
+#define IOMUXC_PAD_SD2_CMD__CCMSRCGPCMIX_OBSERVE1                 0x543c0158, 0x6, 0x543c0000, 0x0, 0x543c0308
+#define IOMUXC_PAD_SD2_DATA0__USDHC2_DATA0                        0x543c015c, 0x0, 0x543c0000, 0x0, 0x543c030c
+#define IOMUXC_PAD_SD2_DATA0__ENET1_1588_EVENT0_OUT               0x543c015c, 0x1, 0x543c0000, 0x0, 0x543c030c
+#define IOMUXC_PAD_SD2_DATA0__CAN2_TX                             0x543c015c, 0x2, 0x543c0000, 0x0, 0x543c030c
+#define IOMUXC_PAD_SD2_DATA0__FLEXIO1_FLEXIO03                    0x543c015c, 0x4, 0x543c0378, 0x1, 0x543c030c
+#define IOMUXC_PAD_SD2_DATA0__GPIO3_IO03                          0x543c015c, 0x5, 0x543c0000, 0x0, 0x543c030c
+#define IOMUXC_PAD_SD2_DATA0__CCMSRCGPCMIX_OBSERVE2               0x543c015c, 0x6, 0x543c0000, 0x0, 0x543c030c
+#define IOMUXC_PAD_SD2_DATA1__USDHC2_DATA1                        0x543c0160, 0x0, 0x543c0000, 0x0, 0x543c0310
+#define IOMUXC_PAD_SD2_DATA1__ENET1_1588_EVENT1_IN                0x543c0160, 0x1, 0x543c0000, 0x0, 0x543c0310
+#define IOMUXC_PAD_SD2_DATA1__CAN2_RX                             0x543c0160, 0x2, 0x543c0364, 0x3, 0x543c0310
+#define IOMUXC_PAD_SD2_DATA1__FLEXIO1_FLEXIO04                    0x543c0160, 0x4, 0x543c037c, 0x1, 0x543c0310
+#define IOMUXC_PAD_SD2_DATA1__GPIO3_IO04                          0x543c0160, 0x5, 0x543c0000, 0x0, 0x543c0310
+#define IOMUXC_PAD_SD2_DATA1__CCMSRCGPCMIX_WAIT                   0x543c0160, 0x6, 0x543c0000, 0x0, 0x543c0310
+#define IOMUXC_PAD_SD2_DATA2__USDHC2_DATA2                        0x543c0164, 0x0, 0x543c0000, 0x0, 0x543c0314
+#define IOMUXC_PAD_SD2_DATA2__ENET1_1588_EVENT1_OUT               0x543c0164, 0x1, 0x543c0000, 0x0, 0x543c0314
+#define IOMUXC_PAD_SD2_DATA2__MQS2_RIGHT                          0x543c0164, 0x2, 0x543c0000, 0x0, 0x543c0314
+#define IOMUXC_PAD_SD2_DATA2__FLEXIO1_FLEXIO05                    0x543c0164, 0x4, 0x543c0380, 0x1, 0x543c0314
+#define IOMUXC_PAD_SD2_DATA2__GPIO3_IO05                          0x543c0164, 0x5, 0x543c0000, 0x0, 0x543c0314
+#define IOMUXC_PAD_SD2_DATA2__CCMSRCGPCMIX_STOP                   0x543c0164, 0x6, 0x543c0000, 0x0, 0x543c0314
+#define IOMUXC_PAD_SD2_DATA3__USDHC2_DATA3                        0x543c0168, 0x0, 0x543c0000, 0x0, 0x543c0318
+#define IOMUXC_PAD_SD2_DATA3__LPTMR2_ALT1                         0x543c0168, 0x1, 0x543c0408, 0x1, 0x543c0318
+#define IOMUXC_PAD_SD2_DATA3__MQS2_LEFT                           0x543c0168, 0x2, 0x543c0000, 0x0, 0x543c0318
+#define IOMUXC_PAD_SD2_DATA3__FLEXIO1_FLEXIO06                    0x543c0168, 0x4, 0x543c0384, 0x1, 0x543c0318
+#define IOMUXC_PAD_SD2_DATA3__GPIO3_IO06                          0x543c0168, 0x5, 0x543c0000, 0x0, 0x543c0318
+#define IOMUXC_PAD_SD2_DATA3__CCMSRCGPCMIX_EARLY_RESET            0x543c0168, 0x6, 0x543c0000, 0x0, 0x543c0318
+#define IOMUXC_PAD_SD2_RESET_B__USDHC2_RESET_B                    0x543c016c, 0x0, 0x543c0000, 0x0, 0x543c031c
+#define IOMUXC_PAD_SD2_RESET_B__LPTMR2_ALT2                       0x543c016c, 0x1, 0x543c040c, 0x1, 0x543c031c
+#define IOMUXC_PAD_SD2_RESET_B__FLEXIO1_FLEXIO07                  0x543c016c, 0x4, 0x543c0388, 0x1, 0x543c031c
+#define IOMUXC_PAD_SD2_RESET_B__GPIO3_IO07                        0x543c016c, 0x5, 0x543c0000, 0x0, 0x543c031c
+#define IOMUXC_PAD_SD2_RESET_B__CCMSRCGPCMIX_SYSTEM_RESET         0x543c016c, 0x6, 0x543c0000, 0x0, 0x543c031c
+#define IOMUXC_PAD_I2C1_SCL__LPI2C1_SCL                           0x543c0170, 0x0, 0x543c0000, 0x0, 0x543c0320
+#define IOMUXC_PAD_I2C1_SCL__I3C1_SCL                             0x543c0170, 0x1, 0x543c0000, 0x0, 0x543c0320
+#define IOMUXC_PAD_I2C1_SCL__LPUART1_DCB_B                        0x543c0170, 0x2, 0x543c0000, 0x0, 0x543c0320
+#define IOMUXC_PAD_I2C1_SCL__TPM2_CH0                             0x543c0170, 0x3, 0x543c0000, 0x0, 0x543c0320
+#define IOMUXC_PAD_I2C1_SCL__GPIO1_IO00                           0x543c0170, 0x5, 0x543c0000, 0x0, 0x543c0320
+#define IOMUXC_PAD_I2C1_SDA__LPI2C1_SDA                           0x543c0174, 0x0, 0x543c0000, 0x0, 0x543c0324
+#define IOMUXC_PAD_I2C1_SDA__I3C1_SDA                             0x543c0174, 0x1, 0x543c0000, 0x0, 0x543c0324
+#define IOMUXC_PAD_I2C1_SDA__LPUART1_RIN_B                        0x543c0174, 0x2, 0x543c0000, 0x0, 0x543c0324
+#define IOMUXC_PAD_I2C1_SDA__TPM2_CH1                             0x543c0174, 0x3, 0x543c0000, 0x0, 0x543c0324
+#define IOMUXC_PAD_I2C1_SDA__GPIO1_IO01                           0x543c0174, 0x5, 0x543c0000, 0x0, 0x543c0324
+#define IOMUXC_PAD_I2C2_SCL__LPI2C2_SCL                           0x543c0178, 0x0, 0x543c0000, 0x0, 0x543c0328
+#define IOMUXC_PAD_I2C2_SCL__I3C1_PUR                             0x543c0178, 0x1, 0x543c0000, 0x0, 0x543c0328
+#define IOMUXC_PAD_I2C2_SCL__LPUART2_DCB_B                        0x543c0178, 0x2, 0x543c0000, 0x0, 0x543c0328
+#define IOMUXC_PAD_I2C2_SCL__TPM2_CH2                             0x543c0178, 0x3, 0x543c0000, 0x0, 0x543c0328
+#define IOMUXC_PAD_I2C2_SCL__SAI1_RX_SYNC                         0x543c0178, 0x4, 0x543c0000, 0x0, 0x543c0328
+#define IOMUXC_PAD_I2C2_SCL__GPIO1_IO02                           0x543c0178, 0x5, 0x543c0000, 0x0, 0x543c0328
+#define IOMUXC_PAD_I2C2_SCL__I3C1_PUR_B                           0x543c0178, 0x6, 0x543c0000, 0x0, 0x543c0328
+#define IOMUXC_PAD_I2C2_SDA__LPI2C2_SDA                           0x543c017c, 0x0, 0x543c0000, 0x0, 0x543c032c
+#define IOMUXC_PAD_I2C2_SDA__LPUART2_RIN_B                        0x543c017c, 0x2, 0x543c0000, 0x0, 0x543c032c
+#define IOMUXC_PAD_I2C2_SDA__TPM2_CH3                             0x543c017c, 0x3, 0x543c0000, 0x0, 0x543c032c
+#define IOMUXC_PAD_I2C2_SDA__SAI1_RX_BCLK                         0x543c017c, 0x4, 0x543c0000, 0x0, 0x543c032c
+#define IOMUXC_PAD_I2C2_SDA__GPIO1_IO03                           0x543c017c, 0x5, 0x543c0000, 0x0, 0x543c032c
+#define IOMUXC_PAD_UART1_RXD__LPUART1_RX                          0x543c0180, 0x0, 0x543c0000, 0x0, 0x543c0330
+#define IOMUXC_PAD_UART1_RXD__S400_UART_RX                        0x543c0180, 0x1, 0x543c0000, 0x0, 0x543c0330
+#define IOMUXC_PAD_UART1_RXD__LPSPI2_SIN                          0x543c0180, 0x2, 0x543c0000, 0x0, 0x543c0330
+#define IOMUXC_PAD_UART1_RXD__TPM1_CH0                            0x543c0180, 0x3, 0x543c0000, 0x0, 0x543c0330
+#define IOMUXC_PAD_UART1_RXD__GPIO1_IO04                          0x543c0180, 0x5, 0x543c0000, 0x0, 0x543c0330
+#define IOMUXC_PAD_UART1_TXD__LPUART1_TX                          0x543c0184, 0x0, 0x543c0000, 0x0, 0x543c0334
+#define IOMUXC_PAD_UART1_TXD__S400_UART_TX                        0x543c0184, 0x1, 0x543c0000, 0x0, 0x543c0334
+#define IOMUXC_PAD_UART1_TXD__LPSPI2_PCS0                         0x543c0184, 0x2, 0x543c0000, 0x0, 0x543c0334
+#define IOMUXC_PAD_UART1_TXD__TPM1_CH1                            0x543c0184, 0x3, 0x543c0000, 0x0, 0x543c0334
+#define IOMUXC_PAD_UART1_TXD__GPIO1_IO05                          0x543c0184, 0x5, 0x543c0000, 0x0, 0x543c0334
+#define IOMUXC_PAD_UART2_RXD__LPUART2_RX                          0x543c0188, 0x0, 0x543c0000, 0x0, 0x543c0338
+#define IOMUXC_PAD_UART2_RXD__LPUART1_CTS_B                       0x543c0188, 0x1, 0x543c0000, 0x0, 0x543c0338
+#define IOMUXC_PAD_UART2_RXD__LPSPI2_SOUT                         0x543c0188, 0x2, 0x543c0000, 0x0, 0x543c0338
+#define IOMUXC_PAD_UART2_RXD__TPM1_CH2                            0x543c0188, 0x3, 0x543c0000, 0x0, 0x543c0338
+#define IOMUXC_PAD_UART2_RXD__SAI1_MCLK                           0x543c0188, 0x4, 0x543c0448, 0x0, 0x543c0338
+#define IOMUXC_PAD_UART2_RXD__GPIO1_IO06                          0x543c0188, 0x5, 0x543c0000, 0x0, 0x543c0338
+#define IOMUXC_PAD_UART2_TXD__LPUART2_TX                          0x543c018c, 0x0, 0x543c0000, 0x0, 0x543c033c
+#define IOMUXC_PAD_UART2_TXD__LPUART1_RTS_B                       0x543c018c, 0x1, 0x543c0000, 0x0, 0x543c033c
+#define IOMUXC_PAD_UART2_TXD__LPSPI2_SCK                          0x543c018c, 0x2, 0x543c0000, 0x0, 0x543c033c
+#define IOMUXC_PAD_UART2_TXD__TPM1_CH3                            0x543c018c, 0x3, 0x543c0000, 0x0, 0x543c033c
+#define IOMUXC_PAD_UART2_TXD__GPIO1_IO07                          0x543c018c, 0x5, 0x543c0000, 0x0, 0x543c033c
+#define IOMUXC_PAD_PDM_CLK__PDM_CLK                               0x543c0190, 0x0, 0x543c0000, 0x0, 0x543c0340
+#define IOMUXC_PAD_PDM_CLK__MQS1_LEFT                             0x543c0190, 0x1, 0x543c0000, 0x0, 0x543c0340
+#define IOMUXC_PAD_PDM_CLK__LPTMR1_ALT1                           0x543c0190, 0x4, 0x543c0000, 0x0, 0x543c0340
+#define IOMUXC_PAD_PDM_CLK__GPIO1_IO08                            0x543c0190, 0x5, 0x543c0000, 0x0, 0x543c0340
+#define IOMUXC_PAD_PDM_CLK__CAN1_TX                               0x543c0190, 0x6, 0x543c0000, 0x0, 0x543c0340
+#define IOMUXC_PAD_PDM_BIT_STREAM0__PDM_BIT_STREAM00              0x543c0194, 0x0, 0x543c0438, 0x2, 0x543c0344
+#define IOMUXC_PAD_PDM_BIT_STREAM0__MQS1_RIGHT                    0x543c0194, 0x1, 0x543c0000, 0x0, 0x543c0344
+#define IOMUXC_PAD_PDM_BIT_STREAM0__LPSPI1_PCS1                   0x543c0194, 0x2, 0x543c0000, 0x0, 0x543c0344
+#define IOMUXC_PAD_PDM_BIT_STREAM0__TPM1_EXTCLK                   0x543c0194, 0x3, 0x543c0000, 0x0, 0x543c0344
+#define IOMUXC_PAD_PDM_BIT_STREAM0__LPTMR1_ALT2                   0x543c0194, 0x4, 0x543c0000, 0x0, 0x543c0344
+#define IOMUXC_PAD_PDM_BIT_STREAM0__GPIO1_IO09                    0x543c0194, 0x5, 0x543c0000, 0x0, 0x543c0344
+#define IOMUXC_PAD_PDM_BIT_STREAM0__CAN1_RX                       0x543c0194, 0x6, 0x543c0360, 0x0, 0x543c0344
+#define IOMUXC_PAD_PDM_BIT_STREAM1__PDM_BIT_STREAM01              0x543c0198, 0x0, 0x543c043c, 0x2, 0x543c0348
+#define IOMUXC_PAD_PDM_BIT_STREAM1__NMI_GLUE_NMI                  0x543c0198, 0x1, 0x543c0000, 0x0, 0x543c0348
+#define IOMUXC_PAD_PDM_BIT_STREAM1__LPSPI2_PCS1                   0x543c0198, 0x2, 0x543c0000, 0x0, 0x543c0348
+#define IOMUXC_PAD_PDM_BIT_STREAM1__TPM2_EXTCLK                   0x543c0198, 0x3, 0x543c0000, 0x0, 0x543c0348
+#define IOMUXC_PAD_PDM_BIT_STREAM1__LPTMR1_ALT3                   0x543c0198, 0x4, 0x543c0000, 0x0, 0x543c0348
+#define IOMUXC_PAD_PDM_BIT_STREAM1__GPIO1_IO10                    0x543c0198, 0x5, 0x543c0000, 0x0, 0x543c0348
+#define IOMUXC_PAD_PDM_BIT_STREAM1__CCMSRCGPCMIX_EXT_CLK1         0x543c0198, 0x6, 0x543c0368, 0x1, 0x543c0348
+#define IOMUXC_PAD_SAI1_TXFS__SAI1_TX_SYNC                        0x543c019c, 0x0, 0x543c0000, 0x0, 0x543c034c
+#define IOMUXC_PAD_SAI1_TXFS__SAI1_TX_DATA01                      0x543c019c, 0x1, 0x543c0000, 0x0, 0x543c034c
+#define IOMUXC_PAD_SAI1_TXFS__LPSPI1_PCS0                         0x543c019c, 0x2, 0x543c0000, 0x0, 0x543c034c
+#define IOMUXC_PAD_SAI1_TXFS__LPUART2_DTR_B                       0x543c019c, 0x3, 0x543c0000, 0x0, 0x543c034c
+#define IOMUXC_PAD_SAI1_TXFS__MQS1_LEFT                           0x543c019c, 0x4, 0x543c0000, 0x0, 0x543c034c
+#define IOMUXC_PAD_SAI1_TXFS__GPIO1_IO11                          0x543c019c, 0x5, 0x543c0000, 0x0, 0x543c034c
+#define IOMUXC_PAD_SAI1_TXC__SAI1_TX_BCLK                         0x543c01a0, 0x0, 0x543c0000, 0x0, 0x543c0350
+#define IOMUXC_PAD_SAI1_TXC__LPUART2_CTS_B                        0x543c01a0, 0x1, 0x543c0000, 0x0, 0x543c0350
+#define IOMUXC_PAD_SAI1_TXC__LPSPI1_SIN                           0x543c01a0, 0x2, 0x543c0000, 0x0, 0x543c0350
+#define IOMUXC_PAD_SAI1_TXC__LPUART1_DSR_B                        0x543c01a0, 0x3, 0x543c0000, 0x0, 0x543c0350
+#define IOMUXC_PAD_SAI1_TXC__CAN1_RX                              0x543c01a0, 0x4, 0x543c0360, 0x1, 0x543c0350
+#define IOMUXC_PAD_SAI1_TXC__GPIO1_IO12                           0x543c01a0, 0x5, 0x543c0000, 0x0, 0x543c0350
+#define IOMUXC_PAD_SAI1_TXD0__SAI1_TX_DATA00                      0x543c01a4, 0x0, 0x543c0000, 0x0, 0x543c0354
+#define IOMUXC_PAD_SAI1_TXD0__LPUART2_RTS_B                       0x543c01a4, 0x1, 0x543c0000, 0x0, 0x543c0354
+#define IOMUXC_PAD_SAI1_TXD0__LPSPI1_SCK                          0x543c01a4, 0x2, 0x543c0000, 0x0, 0x543c0354
+#define IOMUXC_PAD_SAI1_TXD0__LPUART1_DTR_B                       0x543c01a4, 0x3, 0x543c0000, 0x0, 0x543c0354
+#define IOMUXC_PAD_SAI1_TXD0__CAN1_TX                             0x543c01a4, 0x4, 0x543c0000, 0x0, 0x543c0354
+#define IOMUXC_PAD_SAI1_TXD0__GPIO1_IO13                          0x543c01a4, 0x5, 0x543c0000, 0x0, 0x543c0354
+#define IOMUXC_PAD_SAI1_RXD0__SAI1_RX_DATA00                      0x543c01a8, 0x0, 0x543c0000, 0x0, 0x543c0358
+#define IOMUXC_PAD_SAI1_RXD0__SAI1_MCLK                           0x543c01a8, 0x1, 0x543c0448, 0x1, 0x543c0358
+#define IOMUXC_PAD_SAI1_RXD0__LPSPI1_SOUT                         0x543c01a8, 0x2, 0x543c0000, 0x0, 0x543c0358
+#define IOMUXC_PAD_SAI1_RXD0__LPUART2_DSR_B                       0x543c01a8, 0x3, 0x543c0000, 0x0, 0x543c0358
+#define IOMUXC_PAD_SAI1_RXD0__MQS1_RIGHT                          0x543c01a8, 0x4, 0x543c0000, 0x0, 0x543c0358
+#define IOMUXC_PAD_SAI1_RXD0__GPIO1_IO14                          0x543c01a8, 0x5, 0x543c0000, 0x0, 0x543c0358
+#define IOMUXC_PAD_WDOG_ANY__WDOG1_WDOG_ANY                       0x543c01ac, 0x0, 0x543c0000, 0x0, 0x543c035c
+#define IOMUXC_PAD_WDOG_ANY__GPIO1_IO15                           0x543c01ac, 0x5, 0x543c0000, 0x0, 0x543c035c
+/*@}*/
+
+#define IOMUXC_PAD_MUX_MODE_MASK  (0x7U)
+#define IOMUXC_PAD_MUX_MODE_SHIFT (0U)
+#define IOMUXC_PAD_MUX_MODE(x)    (((uint32_t)(((uint32_t)(x)) << IOMUXC_PAD_MUX_MODE_SHIFT)) & IOMUXC_PAD_MUX_MODE_MASK)
+#define IOMUXC_PAD_SION_MASK      (0x10)
+#define IOMUXC_PAD_SION_SHIFT     (4U)
+#define IOMUXC_PAD_SION(x)        (((uint32_t)(((uint32_t)(x)) << IOMUXC_PAD_SION_SHIFT)) & IOMUXC_PAD_SION_MASK)
+
+#define IOMUXC_PAD_DSE_MASK    (0x7EU)
+#define IOMUXC_PAD_DSE_SHIFT   (1U)
+#define IOMUXC_PAD_DSE(x)      (((uint32_t)(((uint32_t)(x)) << IOMUXC_PAD_DSE_SHIFT)) & IOMUXC_PAD_DSE_MASK)
+#define IOMUXC_PAD_FSEL1_MASK  (0x180U)
+#define IOMUXC_PAD_FSEL1_SHIFT (7U)
+#define IOMUXC_PAD_FSEL1(x)    (((uint32_t)(((uint32_t)(x)) << IOMUXC_PAD_FSEL1_SHIFT)) & IOMUXC_PAD_FSEL1_MASK)
+#define IOMUXC_PAD_PU_MASK     (0x200U)
+#define IOMUXC_PAD_PU_SHIFT    (9U)
+#define IOMUXC_PAD_PU(x)       (((uint32_t)(((uint32_t)(x)) << IOMUXC_PAD_PU_SHIFT)) & IOMUXC_PAD_PU_MASK)
+#define IOMUXC_PAD_PD_MASK     (0x400U)
+#define IOMUXC_PAD_PD_SHIFT    (10U)
+#define IOMUXC_PAD_PD(x)       (((uint32_t)(((uint32_t)(x)) << IOMUXC_PAD_PD_SHIFT)) & IOMUXC_PAD_PD_MASK)
+#define IOMUXC_PAD_OD_MASK     (0x800U)
+#define IOMUXC_PAD_OD_SHIFT    (11U)
+#define IOMUXC_PAD_OD(x)       (((uint32_t)(((uint32_t)(x)) << IOMUXC_PAD_OD_SHIFT)) & IOMUXC_PAD_OD_MASK)
+#define IOMUXC_PAD_HYS_MASK    (0x1000U)
+#define IOMUXC_PAD_HYS_SHIFT   (11U)
+#define IOMUXC_PAD_HYS(x)      (((uint32_t)(((uint32_t)(x)) << IOMUXC_PAD_HYS_SHIFT)) & IOMUXC_PAD_HYS_MASK)
+#define IOMUXC_PAD_APC_MASK    (0xFF000000U)
+#define IOMUXC_PAD_APC_SHIFT   (24U)
+#define IOMUXC_PAD_APC(x)      (((uint32_t)(((uint32_t)(x)) << IOMUXC_PAD_APC_SHIFT)) & IOMUXC_PAD_APC_MASK)
+
+/*******************************************************************************
+ * APIs
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /*__cplusplus */
+
+/*! @name Configuration */
+/*@{*/
+
+/*!
+ * @brief Sets the IOMUXC pin mux mode.
+ * @note The first five parameters can be filled with the pin function ID macros.
+ *
+ * @param muxRegister    The pin mux register
+ * @param muxMode        The pin mux mode
+ * @param inputRegister  The select input register
+ * @param inputDaisy     The input daisy
+ * @param configRegister The config register
+ * @param inputOn        The software input on
+ */
+static inline void IOMUXC_SetPinMux(uint32_t muxRegister,
+                                    uint32_t muxMode,
+                                    uint32_t inputRegister,
+                                    uint32_t inputDaisy,
+                                    uint32_t configRegister,
+                                    uint32_t inputOnfield)
+{
+    if (muxRegister)
+    {
+        *((volatile uint32_t *)muxRegister) = IOMUXC_PAD_MUX_MODE(muxMode) | IOMUXC_PAD_SION(inputOnfield);
+    }
+
+    if (inputRegister)
+    {
+        *((volatile uint32_t *)inputRegister) = inputDaisy;
+    }
+}
+/*!
+ * @brief Sets the IOMUXC pin configuration.
+ * @note The previous five parameters can be filled with the pin function ID macros.
+ *
+ * @param muxRegister    The pin mux register
+ * @param muxMode        The pin mux mode
+ * @param inputRegister  The select input register
+ * @param inputDaisy     The input daisy
+ * @param configRegister The config register
+ * @param configValue    The pin config value
+ */
+static inline void IOMUXC_SetPinConfig(uint32_t muxRegister,
+                                       uint32_t muxMode,
+                                       uint32_t inputRegister,
+                                       uint32_t inputDaisy,
+                                       uint32_t configRegister,
+                                       uint32_t configValue)
+{
+    if (configRegister)
+    {
+        *((volatile uint32_t *)configRegister) = configValue;
+    }
+}
+/*@}*/
+
+#if defined(__cplusplus)
+}
+#endif /*__cplusplus */
+
+/*! @}*/
+
+#endif /* _FSL_IOMUXC_H_ */

--- a/devices/MIMX9352/drivers/fsl_memory.h
+++ b/devices/MIMX9352/drivers/fsl_memory.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _FSL_MEMORY_H_
+#define _FSL_MEMORY_H_
+
+#include "fsl_common.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.memory"
+#endif
+/* The CM33 subsystem local TCM start address, refer to Reference Manual for detailed information */
+#define FSL_MEM_M33_TCM_BEGIN 0x20000000U
+/* The CM33 subsystem local TCM end address, refer to Reference Manual for detailed information */
+#define FSL_MEM_M33_TCM_END 0x2001FFFFU
+
+#define FSL_MEM_M33_TCM_OFFSET 0x200000U
+
+typedef enum _mem_direction
+{
+    kMEMORY_Local2DMA = 0,
+    kMEMORY_DMA2Local,
+} mem_direction_t;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif
+/*!
+ * @brief Convert the memory map address.
+ *
+ * This function convert the address between system mapped address and native mapped address.
+ * There maybe offset between subsystem native address and system address for some memory,
+ * this funciton convert the address to different memory map.
+ * @param addr address need to be converted.
+ * @param direction convert direction.
+ * @return the converted address
+ */
+static inline uint32_t MEMORY_ConvertMemoryMapAddress(uint32_t addr, mem_direction_t direction)
+{
+    uint32_t dest;
+
+    switch (direction)
+    {
+        case kMEMORY_Local2DMA:
+        {
+            if ((addr >= FSL_MEM_M33_TCM_BEGIN) && (addr <= FSL_MEM_M33_TCM_END))
+            {
+                dest = addr + FSL_MEM_M33_TCM_OFFSET;
+            }
+            else
+            {
+                dest = addr;
+            }
+            break;
+        }
+        case kMEMORY_DMA2Local:
+        {
+            if ((addr >= (FSL_MEM_M33_TCM_BEGIN + FSL_MEM_M33_TCM_OFFSET)) &&
+                (addr <= (FSL_MEM_M33_TCM_END + FSL_MEM_M33_TCM_OFFSET)))
+            {
+                dest = addr - FSL_MEM_M33_TCM_OFFSET;
+            }
+            else
+            {
+                dest = addr;
+            }
+            break;
+        }
+        default:
+            dest = addr;
+            break;
+    }
+
+    return dest;
+}
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+#endif /* _FSL_MEMORY_H_ */

--- a/devices/MIMX9352/fsl_device_registers.h
+++ b/devices/MIMX9352/fsl_device_registers.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2016 Freescale Semiconductor, Inc.
+ * Copyright 2016-2022 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef __FSL_DEVICE_REGISTERS_H__
+#define __FSL_DEVICE_REGISTERS_H__
+
+/*
+ * Include the cpu specific register header files.
+ *
+ * The CPU macro should be declared in the project or makefile.
+ */
+#if (defined(CPU_MIMX9352CVUXK_cm33) || defined(CPU_MIMX9352DVUXM_cm33))
+
+#define MIMX9352_cm33_SERIES
+
+/* CMSIS-style register definitions */
+#include "MIMX9352_cm33.h"
+/* CPU specific feature definitions */
+#include "MIMX9352_cm33_features.h"
+
+#else
+    #error "No valid CPU defined!"
+#endif
+
+#endif /* __FSL_DEVICE_REGISTERS_H__ */
+
+/*******************************************************************************
+ * EOF
+ ******************************************************************************/

--- a/devices/MIMX9352/fsl_device_registers.h
+++ b/devices/MIMX9352/fsl_device_registers.h
@@ -15,7 +15,16 @@
  *
  * The CPU macro should be declared in the project or makefile.
  */
-#if (defined(CPU_MIMX9352CVUXK_cm33) || defined(CPU_MIMX9352DVUXM_cm33))
+#if (defined(CPU_MIMX9352AVTXM_ca55) || defined(CPU_MIMX9352CVUXK_ca55) || defined(CPU_MIMX9352DVUXM_ca55))
+
+#define MIMX9352_ca55_SERIES
+
+/* CMSIS-style register definitions */
+#include "MIMX9352_ca55.h"
+/* CPU specific feature definitions */
+#include "MIMX9352_ca55_features.h"
+
+#elif (defined(CPU_MIMX9352CVUXK_cm33) || defined(CPU_MIMX9352DVUXM_cm33))
 
 #define MIMX9352_cm33_SERIES
 

--- a/devices/MIMX9352/gcc/MIMX9352_cm33_flash.ld
+++ b/devices/MIMX9352/gcc/MIMX9352_cm33_flash.ld
@@ -1,0 +1,238 @@
+/*
+** ###################################################################
+**     Processors:          MIMX9352CVUXK_cm33
+**                          MIMX9352DVUXM_cm33
+**
+**     Compiler:            GNU C Compiler
+**     Reference manual:    IMX93RM, Internal, November. 2021
+**     Version:             rev. 1.0, 2021-11-16
+**     Build:               b220830
+**
+**     Abstract:
+**         Linker file for the GNU C Compiler
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2022 NXP
+**     All rights reserved.
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+** ###################################################################
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
+STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
+M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0478 : 0x0;
+
+/* Memory region from [0x80000000-0x80001FFF] is reserved for ROM header */
+/* Memory region from [0x20040000-0x2007FFFF] is reserved for A35 ATF */
+
+/* Specify the memory areas */
+MEMORY
+{
+  m_interrupts          (RX)  : ORIGIN = 0x80002000, LENGTH = 0x00000478
+  m_text                (RX)  : ORIGIN = 0x80002478, LENGTH = 0x003FDB88
+  m_data                (RW)  : ORIGIN = 0x0FFE0000, LENGTH = 0x00020000
+  m_data_2              (RW)  : ORIGIN = 0x20008000, LENGTH = 0x00038000
+  m_m33_suspend_ram     (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00002000
+  m_a55_suspend_ram     (RW)  : ORIGIN = 0x20002000, LENGTH = 0x00001000
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into internal flash */
+  .interrupts :
+  {
+    __VECTOR_TABLE = .;
+    __Vectors = .;
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))     /* Startup code */
+    . = ALIGN(4);
+  } > m_interrupts
+
+  .resource_table :
+  {
+    . = ALIGN(8);
+    KEEP(*(.resource_table)) /* Resource table */
+    . = ALIGN(8);
+  } > m_text
+
+  /* The program code and other data goes into internal flash */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)                 /* .text sections (code) */
+    *(.text*)                /* .text* sections (code) */
+    *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)               /* glue arm to thumb code */
+    *(.glue_7t)              /* glue thumb to arm code */
+    *(.eh_frame)
+    KEEP (*(.init))
+    KEEP (*(.fini))
+    . = ALIGN(4);
+  } > m_text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > m_text
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > m_text
+
+ .ctors :
+  {
+    __CTOR_LIST__ = .;
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __CTOR_END__ = .;
+  } > m_text
+
+  .dtors :
+  {
+    __DTOR_LIST__ = .;
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    __DTOR_END__ = .;
+  } > m_text
+
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > m_text
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > m_text
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > m_text
+
+  __etext = .;    /* define a global symbol at end of code */
+  __DATA_ROM = .; /* Symbol is used by startup for data initialization */
+
+  .interrupts_ram :
+  {
+    . = ALIGN(4);
+    __VECTOR_RAM__ = .;
+    __interrupts_ram_start__ = .; /* Create a global symbol at data start */
+    *(.m_interrupts_ram)     /* This is a user defined section */
+    . += M_VECTOR_RAM_SIZE;
+    . = ALIGN(4);
+    __interrupts_ram_end__ = .; /* Define a global symbol at data end */
+  } > m_data
+
+  __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
+  __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
+
+  .data : AT(__DATA_ROM)
+  {
+    __data_start__ = .;      /* create a global symbol at data start */
+    __quickaccess_start__ = .;
+    . = ALIGN(32);
+    *(CodeQuickAccess)
+    *(DataQuickAccess)
+    . = ALIGN(128);
+    __quickaccess_end__ = .;
+    __DATA_RAM = .;
+    *(.data)                 /* .data sections */
+    *(.data*)                /* .data* sections */
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
+  text_end = ORIGIN(m_text) + LENGTH(m_text);
+  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
+
+  /* Uninitialized data section */
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    . = ALIGN(4);
+    __START_BSS = .;
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    __END_BSS = .;
+  } > m_data
+
+  .m33_suspend :
+  {
+    *(M33SuspendRam)
+    . = ALIGN(4);
+  } > m_m33_suspend_ram
+
+  .heap :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    __HeapBase = .;
+    . += HEAP_SIZE;
+    __HeapLimit = .;
+    __heap_limit = .; /* Add for _sbrk */
+  } > m_data_2
+
+  .stack :
+  {
+    . = ALIGN(8);
+    . += STACK_SIZE;
+  } > m_data_2
+
+  /* Initializes stack on the end of block */
+  __StackTop   = ORIGIN(m_data_2) + LENGTH(m_data_2);
+  __StackLimit = __StackTop - STACK_SIZE;
+  PROVIDE(__stack = __StackTop);
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+  ASSERT(__StackLimit >= __HeapLimit, "region m_data_2 overflowed with stack and heap")
+}
+

--- a/devices/MIMX9352/gcc/MIMX9352_cm33_ram.ld
+++ b/devices/MIMX9352/gcc/MIMX9352_cm33_ram.ld
@@ -1,0 +1,230 @@
+/*
+** ###################################################################
+**     Processors:          MIMX9352CVUXK_cm33
+**                          MIMX9352DVUXM_cm33
+**
+**     Compiler:            GNU C Compiler
+**     Reference manual:    IMX93RM, Internal, November. 2021
+**     Version:             rev. 1.0, 2021-11-16
+**     Build:               b220830
+**
+**     Abstract:
+**         Linker file for the GNU C Compiler
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2022 NXP
+**     All rights reserved.
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+** ###################################################################
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
+STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
+M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0478 : 0x0;
+
+
+/* Specify the memory areas */
+MEMORY
+{
+  m_interrupts          (RX)  : ORIGIN = 0x0FFE0000, LENGTH = 0x00000478
+  m_text                (RX)  : ORIGIN = 0x0FFE0478, LENGTH = 0x0001FB88
+  m_data                (RW)  : ORIGIN = 0x20003000, LENGTH = 0x0001D000
+  m_m33_suspend_ram     (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00002000
+  m_a55_suspend_ram     (RW)  : ORIGIN = 0x20002000, LENGTH = 0x00001000
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into internal RAM */
+  .interrupts :
+  {
+    __VECTOR_TABLE = .;
+    __Vectors = .;
+    . = ALIGN(4);
+    KEEP(*(.isr_vector))     /* Startup code */
+    . = ALIGN(4);
+  } > m_interrupts
+
+  .resource_table :
+  {
+    . = ALIGN(8);
+    KEEP(*(.resource_table)) /* Resource table */
+    . = ALIGN(8);
+  } > m_text
+
+  /* The program code and other data goes into internal RAM */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)                 /* .text sections (code) */
+    *(.text*)                /* .text* sections (code) */
+    *(.rodata)               /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)              /* .rodata* sections (constants, strings, etc.) */
+    *(.glue_7)               /* glue arm to thumb code */
+    *(.glue_7t)              /* glue thumb to arm code */
+    *(.eh_frame)
+    KEEP (*(.init))
+    KEEP (*(.fini))
+    . = ALIGN(4);
+  } > m_text
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > m_text
+
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > m_text
+
+ .ctors :
+  {
+    __CTOR_LIST__ = .;
+    /* gcc uses crtbegin.o to find the start of
+       the constructors, so we make sure it is
+       first.  Because this is a wildcard, it
+       doesn't matter if the user does not
+       actually link against crtbegin.o; the
+       linker won't look for a file to match a
+       wildcard.  The wildcard also means that it
+       doesn't matter which directory crtbegin.o
+       is in.  */
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*crtbegin?.o(.ctors))
+    /* We don't want to include the .ctor section from
+       from the crtend.o file until after the sorted ctors.
+       The .ctor section from the crtend file contains the
+       end of ctors marker and it must be last */
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __CTOR_END__ = .;
+  } > m_text
+
+  .dtors :
+  {
+    __DTOR_LIST__ = .;
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*crtbegin?.o(.dtors))
+    KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    __DTOR_END__ = .;
+  } > m_text
+
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > m_text
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > m_text
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > m_text
+
+  __etext = .;    /* define a global symbol at end of code */
+  __DATA_ROM = .; /* Symbol is used by startup for data initialization */
+
+  .interrupts_ram :
+  {
+    . = ALIGN(4);
+    __VECTOR_RAM__ = .;
+    __interrupts_ram_start__ = .; /* Create a global symbol at data start */
+    *(.m_interrupts_ram)     /* This is a user defined section */
+    . += M_VECTOR_RAM_SIZE;
+    . = ALIGN(4);
+    __interrupts_ram_end__ = .; /* Define a global symbol at data end */
+  } > m_data
+
+  __VECTOR_RAM = DEFINED(__ram_vector_table__) ? __VECTOR_RAM__ : ORIGIN(m_interrupts);
+  __RAM_VECTOR_TABLE_SIZE_BYTES = DEFINED(__ram_vector_table__) ? (__interrupts_ram_end__ - __interrupts_ram_start__) : 0x0;
+
+  .data : AT(__DATA_ROM)
+  {
+    . = ALIGN(4);
+    __DATA_RAM = .;
+    __data_start__ = .;      /* create a global symbol at data start */
+    *(.data)                 /* .data sections */
+    *(.data*)                /* .data* sections */
+    KEEP(*(.jcr*))
+    . = ALIGN(4);
+    __data_end__ = .;        /* define a global symbol at data end */
+  } > m_data
+
+  __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
+  text_end = ORIGIN(m_text) + LENGTH(m_text);
+  ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")
+
+  /* Uninitialized data section */
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    . = ALIGN(4);
+    __START_BSS = .;
+    __bss_start__ = .;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    __END_BSS = .;
+  } > m_data
+
+  .m33_suspend :
+  {
+    *(M33SuspendRam)
+    . = ALIGN(4);
+  } > m_m33_suspend_ram
+
+  .heap :
+  {
+    . = ALIGN(8);
+    __end__ = .;
+    PROVIDE(end = .);
+    __HeapBase = .;
+    . += HEAP_SIZE;
+    __HeapLimit = .;
+    __heap_limit = .; /* Add for _sbrk */
+  } > m_data
+
+  .stack :
+  {
+    . = ALIGN(8);
+    . += STACK_SIZE;
+  } > m_data
+
+  /* Initializes stack on the end of block */
+  __StackTop   = ORIGIN(m_data) + LENGTH(m_data);
+  __StackLimit = __StackTop - STACK_SIZE;
+  PROVIDE(__stack = __StackTop);
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+  ASSERT(__StackLimit >= __HeapLimit, "region m_data overflowed with stack and heap")
+}
+

--- a/devices/MIMX9352/gcc/startup_MIMX9352_cm33.S
+++ b/devices/MIMX9352/gcc/startup_MIMX9352_cm33.S
@@ -1,0 +1,1815 @@
+/* ------------------------------------------------------------------------- */
+/*  @file:    startup_MIMX9352_cm33.s                                        */
+/*  @purpose: CMSIS Cortex-M33 Core Device Startup File                      */
+/*            MIMX9352_cm33                                                  */
+/*  @version: 1.0                                                            */
+/*  @date:    2021-11-16                                                     */
+/*  @build:   b220830                                                        */
+/* ------------------------------------------------------------------------- */
+/*                                                                           */
+/* Copyright 1997-2016 Freescale Semiconductor, Inc.                         */
+/* Copyright 2016-2022 NXP                                                   */
+/* All rights reserved.                                                      */
+/*                                                                           */
+/* SPDX-License-Identifier: BSD-3-Clause                                     */
+/*****************************************************************************/
+/* Version: GCC for ARM Embedded Processors                                  */
+/*****************************************************************************/
+    .syntax unified
+    .arch armv8-m.main
+
+    .section .isr_vector, "a"
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long   __StackTop                                      /* Top of Stack */
+    .long   Reset_Handler                                   /* Reset Handler */
+    .long   NMI_Handler                                     /* NMI Handler*/
+    .long   HardFault_Handler                               /* Hard Fault Handler*/
+    .long   MemManage_Handler                               /* MPU Fault Handler*/
+    .long   BusFault_Handler                                /* Bus Fault Handler*/
+    .long   UsageFault_Handler                              /* Usage Fault Handler*/
+    .long   SecureFault_Handler                             /* Secure Fault Handler*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   SVC_Handler                                     /* SVCall Handler*/
+    .long   DebugMon_Handler                                /* Debug Monitor Handler*/
+    .long   0                                               /* Reserved*/
+    .long   PendSV_Handler                                  /* PendSV Handler*/
+    .long   SysTick_Handler                                 /* SysTick Handler*/
+
+                                                            /* External Interrupts*/
+    .long   Reserved16_IRQHandler                           /* Exception condition notification while boot */
+    .long   Reserved17_IRQHandler                           /* DAP interrupt */
+    .long   Reserved18_IRQHandler                           /* Reserved interrupt */
+    .long   Reserved19_IRQHandler                           /* CTI trigger outputs from CM33 platform */
+    .long   Reserved20_IRQHandler                           /* CTI trigger outputs from CA55 platform */
+    .long   Reserved21_IRQHandler                           /* Performance Unit Interrupts from CA55 platform */
+    .long   Reserved22_IRQHandler                           /* ECC error from CA55 platform cache */
+    .long   Reserved23_IRQHandler                           /* 1-bit or 2-bit ECC or Parity error from CA55 platform cache */
+    .long   CAN1_IRQHandler                                 /* CAN1 interrupt*/
+    .long   CAN1_ERROR_IRQHandler                           /* CAN1 error interrupt*/
+    .long   Reserved26_IRQHandler                           /* General Purpose Input/Output 1 interrupt 0 */
+    .long   Reserved27_IRQHandler                           /* General Purpose Input/Output 1 interrupt 1 */
+    .long   I3C1_IRQHandler                                 /* Improved Inter-Integrated Circuit 1 interrupt */
+    .long   LPI2C1_IRQHandler                               /* Low Power Inter-Integrated Circuit module 1 */
+    .long   LPI2C2_IRQHandler                               /* Low Power Inter-Integrated Circuit module 2 */
+    .long   LPIT1_IRQHandler                                /* Low Power Periodic Interrupt Timer 1 */
+    .long   LPSPI1_IRQHandler                               /* Low Power Serial Peripheral Interface 1 */
+    .long   LPSPI2_IRQHandler                               /* Low Power Serial Peripheral Interface 2 */
+    .long   LPTMR1_IRQHandler                               /* Low Power Timer 1 */
+    .long   LPUART1_IRQHandler                              /* Low Power UART 1 */
+    .long   LPUART2_IRQHandler                              /* Low Power UART 2 */
+    .long   MU1_A_IRQHandler                                /* Messaging Unit 1 - Side A (to communicate with M7 core) */
+    .long   MU1_B_IRQHandler                                /* Messaging Unit 1 - Side B (to communicate with M33 core) */
+    .long   MU2_A_IRQHandler                                /* Messaging Unit 2 - Side A (to communicate with M7 core) */
+    .long   MU2_B_IRQHandler                                /* Messaging Unit 2 - Side B (to communicate with A55 core) */
+    .long   Reserved41_IRQHandler                           /* Reserved interrupt */
+    .long   Reserved42_IRQHandler                           /* Reserved interrupt */
+    .long   Reserved43_IRQHandler                           /* Reserved interrupt */
+    .long   Reserved44_IRQHandler                           /* Edgelock Trust MUA RX full interrupt */
+    .long   Reserved45_IRQHandler                           /* Edgelock Trust MUA TX empty interrupt */
+    .long   Reserved46_IRQHandler                           /* Edgelock Apps Core MUA RX full interrupt */
+    .long   Reserved47_IRQHandler                           /* Edgelock Apps Core MUA TX empty interrupt */
+    .long   Reserved48_IRQHandler                           /* Edgelock Realtime Core MUA RX full interrupt */
+    .long   Reserved49_IRQHandler                           /* Edgelock Realtime Core MUA TX empty interrupt */
+    .long   Reserved50_IRQHandler                           /* Edgelock secure interrupt */
+    .long   Reserved51_IRQHandler                           /* Edgelock non-secure interrupt */
+    .long   TPM1_IRQHandler                                 /* Timer PWM module 1 */
+    .long   TPM2_IRQHandler                                 /* Timer PWM module 2 */
+    .long   WDOG1_IRQHandler                                /* Watchdog 1 Interrupt */
+    .long   WDOG2_IRQHandler                                /* Watchdog 2 Interrupt */
+    .long   TRDC_IRQHandler                                 /* AONMIX TRDC transfer error interrupt */
+    .long   Reserved57_IRQHandler                           /* Reserved interrupt */
+    .long   Reserved58_IRQHandler                           /* Reserved interrupt */
+    .long   Reserved59_IRQHandler                           /* Reserved interrupt */
+    .long   Reserved60_IRQHandler                           /* Reserved interrupt */
+    .long   SAI1_IRQHandler                                 /* Serial Audio Interface 1 */
+    .long   Reserved62_IRQHandler                           /* M33 PS Tag/Data Parity Error */
+    .long   Reserved63_IRQHandler                           /* M33 TCM ECC interrupt */
+    .long   Reserved64_IRQHandler                           /* M33 TCM Error interrupt */
+    .long   Reserved65_IRQHandler                           /* Reserved interrupt */
+    .long   Reserved66_IRQHandler                           /* Reserved interrupt */
+    .long   CAN2_IRQHandler                                 /* CAN2 interrupt*/
+    .long   CAN2_ERROR_IRQHandler                           /* CAN2 error interrupt*/
+    .long   FLEXIO1_IRQHandler                              /* Flexible IO 1 interrupt */
+    .long   FLEXIO2_IRQHandler                              /* Flexible IO 2 interrupt */
+    .long   FlexSPI1_IRQHandler                             /* FlexSPI controller interface interrupt 1 */
+    .long   Reserved72_IRQHandler                           /* Reserved interrupt */
+    .long   Reserved73_IRQHandler                           /* General Purpose Input/Output 2 interrupt 0 */
+    .long   Reserved74_IRQHandler                           /* General Purpose Input/Output 2 interrupt 1 */
+    .long   Reserved75_IRQHandler                           /* General Purpose Input/Output 3 interrupt 0 */
+    .long   Reserved76_IRQHandler                           /* General Purpose Input/Output 3 interrupt 1 */
+    .long   I3C2_IRQHandler                                 /* Improved Inter-Integrated Circuit 2 interrupt */
+    .long   LPI2C3_IRQHandler                               /* Low Power Inter-Integrated Circuit module 3 */
+    .long   LPI2C4_IRQHandler                               /* Low Power Inter-Integrated Circuit module 4 */
+    .long   LPIT2_IRQHandler                                /* Low Power Periodic Interrupt Timer 2 */
+    .long   LPSPI3_IRQHandler                               /* Low Power Serial Peripheral Interface 3 */
+    .long   LPSPI4_IRQHandler                               /* Low Power Serial Peripheral Interface 4 */
+    .long   LPTMR2_IRQHandler                               /* Low Power Timer 2 */
+    .long   LPUART3_IRQHandler                              /* Low Power UART 3 */
+    .long   LPUART4_IRQHandler                              /* Low Power UART 4 */
+    .long   LPUART5_IRQHandler                              /* Low Power UART 5 */
+    .long   LPUART6_IRQHandler                              /* Low Power UART 6 */
+    .long   Reserved88_IRQHandler                           /* MTR Master error interrupt */
+    .long   Reserved89_IRQHandler                           /* BBNSM Non-Secure interrupt */
+    .long   Reserved90_IRQHandler                           /* System Counter compare interrupt */
+    .long   TPM3_IRQHandler                                 /* Timer PWM module 3 */
+    .long   TPM4_IRQHandler                                 /* Timer PWM module 4 */
+    .long   TPM5_IRQHandler                                 /* Timer PWM module 5 */
+    .long   TPM6_IRQHandler                                 /* Timer PWM module 6 */
+    .long   WDOG3_IRQHandler                                /* Watchdog 3 Interrupt */
+    .long   WDOG4_IRQHandler                                /* Watchdog 4 Interrupt */
+    .long   WDOG5_IRQHandler                                /* Watchdog 5 Interrupt */
+    .long   Reserved98_IRQHandler                           /* WAKEUPMIX TRDC transfer error interrupt */
+    .long   Reserved99_IRQHandler                           /* TempSensor interrupt */
+    .long   Reserved100_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved101_IRQHandler                          /* Reserved interrupt */
+    .long   uSDHC1_IRQHandler                               /* ultra Secure Digital Host Controller interrupt 1 */
+    .long   uSDHC2_IRQHandler                               /* ultra Secure Digital Host Controller interrupt 2 */
+    .long   Reserved104_IRQHandler                          /* MEGAMIX TRDC transfer error interrupt */
+    .long   Reserved105_IRQHandler                          /* NIC_WRAPPER TRDC transfer error interrupt */
+    .long   Reserved106_IRQHandler                          /* DRAM controller Performance Monitor Interrupt */
+    .long   Reserved107_IRQHandler                          /* DRAM controller Critical Interrupt */
+    .long   Reserved108_IRQHandler                          /* DRAM Phy Critical Interrupt */
+    .long   Reserved109_IRQHandler                          /* Reserved interrupt */
+    .long   DMA3_ERROR_IRQHandler                           /* eDMA0 error interrupt */
+    .long   DMA3_0_IRQHandler                               /* eDMA0 Channel 0 interrupt */
+    .long   DMA3_1_IRQHandler                               /* eDMA0 Channel 1 interrupt */
+    .long   DMA3_2_IRQHandler                               /* eDMA0 Channel 2 interrupt */
+    .long   DMA3_3_IRQHandler                               /* eDMA0 Channel 3 interrupt */
+    .long   DMA3_4_IRQHandler                               /* eDMA0 Channel 4 interrupt */
+    .long   DMA3_5_IRQHandler                               /* eDMA0 Channel 5 interrupt */
+    .long   DMA3_6_IRQHandler                               /* eDMA0 Channel 6 interrupt */
+    .long   DMA3_7_IRQHandler                               /* eDMA0 Channel 7 interrupt */
+    .long   DMA3_8_IRQHandler                               /* eDMA0 Channel 8 interrupt */
+    .long   DMA3_9_IRQHandler                               /* eDMA0 Channel 9 interrupt */
+    .long   DMA3_10_IRQHandler                              /* eDMA0 Channel 10 interrupt */
+    .long   DMA3_11_IRQHandler                              /* eDMA0 Channel 11 interrupt */
+    .long   DMA3_12_IRQHandler                              /* eDMA0 Channel 12 interrupt */
+    .long   DMA3_13_IRQHandler                              /* eDMA0 Channel 13 interrupt */
+    .long   DMA3_14_IRQHandler                              /* eDMA0 Channel 14 interrupt */
+    .long   DMA3_15_IRQHandler                              /* eDMA0 Channel 15 interrupt */
+    .long   DMA3_16_IRQHandler                              /* eDMA0 Channel 16 interrupt */
+    .long   DMA3_17_IRQHandler                              /* eDMA0 Channel 17 interrupt */
+    .long   DMA3_18_IRQHandler                              /* eDMA0 Channel 18 interrupt */
+    .long   DMA3_19_IRQHandler                              /* eDMA0 Channel 19 interrupt */
+    .long   DMA3_20_IRQHandler                              /* eDMA0 Channel 20 interrupt */
+    .long   DMA3_21_IRQHandler                              /* eDMA0 Channel 21 interrupt */
+    .long   DMA3_22_IRQHandler                              /* eDMA0 Channel 22 interrupt */
+    .long   DMA3_23_IRQHandler                              /* eDMA0 Channel 23 interrupt */
+    .long   DMA3_24_IRQHandler                              /* eDMA0 Channel 24 interrupt */
+    .long   DMA3_25_IRQHandler                              /* eDMA0 Channel 25 interrupt */
+    .long   DMA3_26_IRQHandler                              /* eDMA0 Channel 26 interrupt */
+    .long   DMA3_27_IRQHandler                              /* eDMA0 Channel 27 interrupt */
+    .long   DMA3_28_IRQHandler                              /* eDMA0 Channel 28 interrupt */
+    .long   DMA3_29_IRQHandler                              /* eDMA0 Channel 29 interrupt */
+    .long   DMA3_30_IRQHandler                              /* eDMA0 Channel 30 interrupt */
+    .long   Reserved142_IRQHandler                          /* Reserved interrupt */
+    .long   DMA4_ERROR_IRQHandler                           /* eDMA2 error interrupt */
+    .long   DMA4_0_1_IRQHandler                             /* eDMA2 channel 0/1 interrupt */
+    .long   DMA4_2_3_IRQHandler                             /* eDMA2 channel 2/3 interrupt */
+    .long   DMA4_4_5_IRQHandler                             /* eDMA2 channel 4/5 interrupt */
+    .long   DMA4_6_7_IRQHandler                             /* eDMA2 channel 6/7 interrupt */
+    .long   DMA4_8_9_IRQHandler                             /* eDMA2 channel 8/9 interrupt */
+    .long   DMA4_10_11_IRQHandler                           /* eDMA2 channel 10/11 interrupt */
+    .long   DMA4_12_13_IRQHandler                           /* eDMA2 channel 12/13 interrupt */
+    .long   DMA4_14_15_IRQHandler                           /* eDMA2 channel 14/15 interrupt */
+    .long   DMA4_16_17_IRQHandler                           /* eDMA2 channel 16/17 interrupt */
+    .long   DMA4_18_19_IRQHandler                           /* eDMA2 channel 18/19 interrupt */
+    .long   DMA4_20_21_IRQHandler                           /* eDMA2 channel 20/21 interrupt */
+    .long   DMA4_22_23_IRQHandler                           /* eDMA2 channel 22/23 interrupt */
+    .long   DMA4_24_25_IRQHandler                           /* eDMA2 channel 24/25 interrupt */
+    .long   DMA4_26_27_IRQHandler                           /* eDMA2 channel 26/27 interrupt */
+    .long   DMA4_28_29_IRQHandler                           /* eDMA2 channel 28/29 interrupt */
+    .long   DMA4_30_31_IRQHandler                           /* eDMA2 channel 30/31 interrupt */
+    .long   DMA4_32_33_IRQHandler                           /* eDMA2 channel 32/33 interrupt */
+    .long   DMA4_34_35_IRQHandler                           /* eDMA2 channel 34/35 interrupt */
+    .long   DMA4_36_37_IRQHandler                           /* eDMA2 channel 36/37 interrupt */
+    .long   DMA4_38_39_IRQHandler                           /* eDMA2 channel 38/39 interrupt */
+    .long   DMA4_40_41_IRQHandler                           /* eDMA2 channel 40/41 interrupt */
+    .long   DMA4_42_43_IRQHandler                           /* eDMA2 channel 42/43 interrupt */
+    .long   DMA4_44_45_IRQHandler                           /* eDMA2 channel 44/45 interrupt */
+    .long   DMA4_46_47_IRQHandler                           /* eDMA2 channel 46/47 interrupt */
+    .long   DMA4_48_49_IRQHandler                           /* eDMA2 channel 48/49 interrupt */
+    .long   DMA4_50_51_IRQHandler                           /* eDMA2 channel 50/51 interrupt */
+    .long   DMA4_52_53_IRQHandler                           /* eDMA2 channel 52/53 interrupt */
+    .long   DMA4_54_55_IRQHandler                           /* eDMA2 channel 54/55 interrupt */
+    .long   DMA4_56_57_IRQHandler                           /* eDMA2 channel 56/57 interrupt */
+    .long   DMA4_58_59_IRQHandler                           /* eDMA2 channel 58/59 interrupt */
+    .long   DMA4_60_61_IRQHandler                           /* eDMA2 channel 60/61 interrupt */
+    .long   DMA4_62_63_IRQHandler                           /* eDMA2 channel 62/63 interrupt */
+    .long   Reserved176_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved177_IRQHandler                          /* Edgelock Group 1 reset source */
+    .long   Reserved178_IRQHandler                          /* Edgelock Group 2 reset source */
+    .long   Reserved179_IRQHandler                          /* Edgelock Group 2 reset source */
+    .long   Reserved180_IRQHandler                          /* JTAGSW DAP MDM-AP SRC reset source */
+    .long   Reserved181_IRQHandler                          /* JTAGC SRC reset source */
+    .long   Reserved182_IRQHandler                          /* CM33 SYSREQRST SRC reset source */
+    .long   Reserved183_IRQHandler                          /* CM33 LOCKUP SRC reset source */
+    .long   Reserved184_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved185_IRQHandler                          /* Reserved interrupt */
+    .long   SAI2_IRQHandler                                 /* Serial Audio Interface 2 */
+    .long   SAI3_IRQHandler                                 /* Serial Audio Interface 3 */
+    .long   ISI_IRQHandler                                  /* ISI interrupt */
+    .long   Reserved189_IRQHandler                          /* PXP interrupt 0 */
+    .long   Reserved190_IRQHandler                          /* PXP interrupt 1 */
+    .long   CSI_IRQHandler                                  /* CSI interrupt */
+    .long   Reserved192_IRQHandler                          /* LCDIF Sync Interrupt */
+    .long   DSI_IRQHandler                                  /* MIPI DSI Interrupt Request */
+    .long   Reserved194_IRQHandler                          /* Machine learning processor interrupt */
+    .long   ENET_MAC0_Rx_Tx_Done1_IRQHandler                /* MAC 0 Receive / Trasmit Frame / Buffer Done*/
+    .long   ENET_MAC0_Rx_Tx_Done2_IRQHandler                /* MAC 0 Receive / Trasmit Frame / Buffer Done*/
+    .long   ENET_IRQHandler                                 /* MAC 0 IRQ*/
+    .long   ENET_1588_IRQHandler                            /* MAC 0 1588 Timer Interrupt - synchronous*/
+    .long   ENET_QOS_PMT_IRQHandler                         /* ENET QOS PMT interrupt */
+    .long   ENET_QOS_IRQHandler                             /* ENET QOS interrupt */
+    .long   Reserved201_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved202_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved203_IRQHandler                          /* USB-1 Wake-up Interrupt */
+    .long   Reserved204_IRQHandler                          /* USB-2 Wake-up Interrupt */
+    .long   Reserved205_IRQHandler                          /* General Purpose Input/Output 4 interrupt 0 */
+    .long   Reserved206_IRQHandler                          /* General Purpose Input/Output 4 interrupt 1 */
+    .long   LPSPI5_IRQHandler                               /* Low Power Serial Peripheral Interface 5 */
+    .long   LPSPI6_IRQHandler                               /* Low Power Serial Peripheral Interface 6 */
+    .long   LPSPI7_IRQHandler                               /* Low Power Serial Peripheral Interface 7 */
+    .long   LPSPI8_IRQHandler                               /* Low Power Serial Peripheral Interface 8 */
+    .long   LPI2C5_IRQHandler                               /* Low Power Inter-Integrated Circuit module 5 */
+    .long   LPI2C6_IRQHandler                               /* Low Power Inter-Integrated Circuit module 6 */
+    .long   LPI2C7_IRQHandler                               /* Low Power Inter-Integrated Circuit module 7 */
+    .long   LPI2C8_IRQHandler                               /* Low Power Inter-Integrated Circuit module 8 */
+    .long   PDM_HWVAD_ERROR_IRQHandler                      /* PDM interrupt */
+    .long   PDM_HWVAD_EVENT_IRQHandler                      /* PDM interrupt */
+    .long   PDM_ERROR_IRQHandler                            /* PDM interrupt */
+    .long   PDM_EVENT_IRQHandler                            /* PDM interrupt */
+    .long   Reserved219_IRQHandler                          /* AUDIO XCVR interrupt */
+    .long   Reserved220_IRQHandler                          /* AUDIO XCVR interrupt */
+    .long   uSDHC3_IRQHandler                               /* ultra Secure Digital Host Controller interrupt 3 */
+    .long   Reserved222_IRQHandler                          /* OCRAM MECC interrupt */
+    .long   Reserved223_IRQHandler                          /* OCRAM MECC interrupt */
+    .long   Reserved224_IRQHandler                          /* HSIOMIX TRDC transfer error interrupt */
+    .long   Reserved225_IRQHandler                          /* MEDIAMIX TRDC transfer error interrupt */
+    .long   LPUART7_IRQHandler                              /* Low Power UART 7 */
+    .long   LPUART8_IRQHandler                              /* Low Power UART 8 */
+    .long   Reserved228_IRQHandler                          /* CM33 MCM interrupt */
+    .long   Reserved229_IRQHandler                          /* SFA interrupt */
+    .long   Reserved230_IRQHandler                          /* GIC600 INTERRUPT */
+    .long   Reserved231_IRQHandler                          /* GIC600 INTERRUPT */
+    .long   Reserved232_IRQHandler                          /* GIC600 INTERRUPT */
+    .long   Reserved233_IRQHandler                          /* ADC interrupt */
+    .long   Reserved234_IRQHandler                          /* ADC interrupt */
+    .long   Reserved235_IRQHandler                          /* ADC interrupt */
+    .long   Reserved236_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved237_IRQHandler                          /* I3C1 wakeup irq after double sync */
+    .long   Reserved238_IRQHandler                          /* I3C2 wakeup irq after double sync */
+    .long   Reserved239_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved240_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved241_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved242_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved243_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved244_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved245_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved246_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved247_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved248_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved249_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved250_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved251_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved252_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved253_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved254_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved255_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved256_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved257_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved258_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved259_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved260_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved261_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved262_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved263_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved264_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved265_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved266_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved267_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved268_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved269_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved270_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved271_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved272_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved273_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved274_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved275_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved276_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved277_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved278_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved279_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved280_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved281_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved282_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved283_IRQHandler                          /* Reserved interrupt */
+    .long   Reserved284_IRQHandler                          /* ADC Asynchronous Interrupt */
+
+    .size    __isr_vector, . - __isr_vector
+
+    .text
+    .thumb
+
+/* Reset Handler */
+
+    .thumb_func
+    .align 2
+    .globl   Reset_Handler
+    .weak    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+    cpsid   i               /* Mask interrupts */
+    .equ    VTOR, 0xE000ED08
+    ldr     r0, =VTOR
+    ldr     r1, =__isr_vector
+    str     r1, [r0]
+    ldr     r2, [r1]
+    msr     msp, r2
+#ifndef __NO_SYSTEM_INIT
+    ldr   r0,=SystemInit
+    blx   r0
+#endif
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+#ifdef __PERFORMANCE_IMPLEMENTATION
+/* Here are two copies of loop implementations. First one favors performance
+ * and the second one favors code size. Default uses the second one.
+ * Define macro "__PERFORMANCE_IMPLEMENTATION" in project to use the first one */
+    subs    r3, r2
+    ble    .LC1
+.LC0:
+    subs    r3, #4
+    ldr    r0, [r1, r3]
+    str    r0, [r2, r3]
+    bgt    .LC0
+.LC1:
+#else  /* code size implemenation */
+.LC0:
+    cmp     r2, r3
+    ittt    lt
+    ldrlt   r0, [r1], #4
+    strlt   r0, [r2], #4
+    blt    .LC0
+#endif
+
+#ifdef __STARTUP_CLEAR_BSS
+/*     This part of work usually is done in C library startup code. Otherwise,
+ *     define this macro to enable it in this startup.
+ *
+ *     Loop to zero out BSS section, which uses following symbols
+ *     in linker script:
+ *      __bss_start__: start of BSS section. Must align to 4
+ *      __bss_end__: end of BSS section. Must align to 4
+ */
+    ldr r1, =__bss_start__
+    ldr r2, =__bss_end__
+
+    movs    r0, 0
+.LC2:
+    cmp     r1, r2
+    itt    lt
+    strlt   r0, [r1], #4
+    blt    .LC2
+#endif /* __STARTUP_CLEAR_BSS */
+
+/* Add stack / heap initializaiton */
+    movs    r0, 0
+    ldr     r1, =__HeapBase
+    ldr     r2, =__HeapLimit
+.LC3:
+    cmp     r1, r2
+    itt     lt
+    strlt   r0, [r1], #4
+    blt     .LC3
+
+    ldr     r1, =__StackLimit
+    ldr     r2, =__StackTop
+.LC4:
+    cmp     r1, r2
+    itt     lt
+    strlt   r0, [r1], #4
+    blt     .LC4
+/*End of stack / heap initializaiton */
+    cpsie   i               /* Unmask interrupts */
+#ifndef __START
+#define __START _start
+#endif
+#ifndef __ATOLLIC__
+    ldr   r0,=__START
+    blx   r0
+#else
+    ldr   r0,=__libc_init_array
+    blx   r0
+    ldr   r0,=main
+    bx    r0
+#endif
+    .pool
+    .size Reset_Handler, . - Reset_Handler
+
+    .align  1
+    .thumb_func
+    .weak DefaultISR
+    .type DefaultISR, %function
+DefaultISR:
+    b DefaultISR
+    .size DefaultISR, . - DefaultISR
+
+    .align 1
+    .thumb_func
+    .weak NMI_Handler
+    .type NMI_Handler, %function
+NMI_Handler:
+    ldr   r0,=NMI_Handler
+    bx    r0
+    .size NMI_Handler, . - NMI_Handler
+
+    .align 1
+    .thumb_func
+    .weak HardFault_Handler
+    .type HardFault_Handler, %function
+HardFault_Handler:
+    ldr   r0,=HardFault_Handler
+    bx    r0
+    .size HardFault_Handler, . - HardFault_Handler
+
+    .align 1
+    .thumb_func
+    .weak SVC_Handler
+    .type SVC_Handler, %function
+SVC_Handler:
+    ldr   r0,=SVC_Handler
+    bx    r0
+    .size SVC_Handler, . - SVC_Handler
+
+    .align 1
+    .thumb_func
+    .weak PendSV_Handler
+    .type PendSV_Handler, %function
+PendSV_Handler:
+    ldr   r0,=PendSV_Handler
+    bx    r0
+    .size PendSV_Handler, . - PendSV_Handler
+
+    .align 1
+    .thumb_func
+    .weak SysTick_Handler
+    .type SysTick_Handler, %function
+SysTick_Handler:
+    ldr   r0,=SysTick_Handler
+    bx    r0
+    .size SysTick_Handler, . - SysTick_Handler
+
+    .align 1
+    .thumb_func
+    .weak CAN1_IRQHandler
+    .type CAN1_IRQHandler, %function
+CAN1_IRQHandler:
+    ldr   r0,=CAN1_DriverIRQHandler
+    bx    r0
+    .size CAN1_IRQHandler, . - CAN1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN1_ERROR_IRQHandler
+    .type CAN1_ERROR_IRQHandler, %function
+CAN1_ERROR_IRQHandler:
+    ldr   r0,=CAN1_ERROR_DriverIRQHandler
+    bx    r0
+    .size CAN1_ERROR_IRQHandler, . - CAN1_ERROR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I3C1_IRQHandler
+    .type I3C1_IRQHandler, %function
+I3C1_IRQHandler:
+    ldr   r0,=I3C1_DriverIRQHandler
+    bx    r0
+    .size I3C1_IRQHandler, . - I3C1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPI2C1_IRQHandler
+    .type LPI2C1_IRQHandler, %function
+LPI2C1_IRQHandler:
+    ldr   r0,=LPI2C1_DriverIRQHandler
+    bx    r0
+    .size LPI2C1_IRQHandler, . - LPI2C1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPI2C2_IRQHandler
+    .type LPI2C2_IRQHandler, %function
+LPI2C2_IRQHandler:
+    ldr   r0,=LPI2C2_DriverIRQHandler
+    bx    r0
+    .size LPI2C2_IRQHandler, . - LPI2C2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak FlexCAN_IRQHandler
+    .type FlexCAN_IRQHandler, %function
+
+    .align 1
+    .thumb_func
+    .weak LPSPI1_IRQHandler
+    .type LPSPI1_IRQHandler, %function
+LPSPI1_IRQHandler:
+    ldr   r0,=LPSPI1_DriverIRQHandler
+    bx    r0
+    .size LPSPI1_IRQHandler, . - LPSPI1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPSPI2_IRQHandler
+    .type LPSPI2_IRQHandler, %function
+LPSPI2_IRQHandler:
+    ldr   r0,=LPSPI2_DriverIRQHandler
+    bx    r0
+    .size LPSPI2_IRQHandler, . - LPSPI2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPUART1_IRQHandler
+    .type LPUART1_IRQHandler, %function
+LPUART1_IRQHandler:
+    ldr   r0,=LPUART1_DriverIRQHandler
+    bx    r0
+    .size LPUART1_IRQHandler, . - LPUART1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPUART2_IRQHandler
+    .type LPUART2_IRQHandler, %function
+LPUART2_IRQHandler:
+    ldr   r0,=LPUART2_DriverIRQHandler
+    bx    r0
+    .size LPUART2_IRQHandler, . - LPUART2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SAI1_IRQHandler
+    .type SAI1_IRQHandler, %function
+SAI1_IRQHandler:
+    ldr   r0,=SAI1_DriverIRQHandler
+    bx    r0
+    .size SAI1_IRQHandler, . - SAI1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN2_IRQHandler
+    .type CAN2_IRQHandler, %function
+CAN2_IRQHandler:
+    ldr   r0,=CAN2_DriverIRQHandler
+    bx    r0
+    .size CAN2_IRQHandler, . - CAN2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak CAN2_ERROR_IRQHandler
+    .type CAN2_ERROR_IRQHandler, %function
+CAN2_ERROR_IRQHandler:
+    ldr   r0,=CAN2_ERROR_DriverIRQHandler
+    bx    r0
+    .size CAN2_ERROR_IRQHandler, . - CAN2_ERROR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak FLEXIO1_IRQHandler
+    .type FLEXIO1_IRQHandler, %function
+FLEXIO1_IRQHandler:
+    ldr   r0,=FLEXIO1_DriverIRQHandler
+    bx    r0
+    .size FLEXIO1_IRQHandler, . - FLEXIO1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak FLEXIO2_IRQHandler
+    .type FLEXIO2_IRQHandler, %function
+FLEXIO2_IRQHandler:
+    ldr   r0,=FLEXIO2_DriverIRQHandler
+    bx    r0
+    .size FLEXIO2_IRQHandler, . - FLEXIO2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak FlexSPI1_IRQHandler
+    .type FlexSPI1_IRQHandler, %function
+FlexSPI1_IRQHandler:
+    ldr   r0,=FlexSPI1_DriverIRQHandler
+    bx    r0
+    .size FlexSPI1_IRQHandler, . - FlexSPI1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak I3C2_IRQHandler
+    .type I3C2_IRQHandler, %function
+I3C2_IRQHandler:
+    ldr   r0,=I3C2_DriverIRQHandler
+    bx    r0
+    .size I3C2_IRQHandler, . - I3C2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPI2C3_IRQHandler
+    .type LPI2C3_IRQHandler, %function
+LPI2C3_IRQHandler:
+    ldr   r0,=LPI2C3_DriverIRQHandler
+    bx    r0
+    .size LPI2C3_IRQHandler, . - LPI2C3_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPI2C4_IRQHandler
+    .type LPI2C4_IRQHandler, %function
+LPI2C4_IRQHandler:
+    ldr   r0,=LPI2C4_DriverIRQHandler
+    bx    r0
+    .size LPI2C4_IRQHandler, . - LPI2C4_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPSPI3_IRQHandler
+    .type LPSPI3_IRQHandler, %function
+LPSPI3_IRQHandler:
+    ldr   r0,=LPSPI3_DriverIRQHandler
+    bx    r0
+    .size LPSPI3_IRQHandler, . - LPSPI3_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPSPI4_IRQHandler
+    .type LPSPI4_IRQHandler, %function
+LPSPI4_IRQHandler:
+    ldr   r0,=LPSPI4_DriverIRQHandler
+    bx    r0
+    .size LPSPI4_IRQHandler, . - LPSPI4_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPUART3_IRQHandler
+    .type LPUART3_IRQHandler, %function
+LPUART3_IRQHandler:
+    ldr   r0,=LPUART3_DriverIRQHandler
+    bx    r0
+    .size LPUART3_IRQHandler, . - LPUART3_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPUART4_IRQHandler
+    .type LPUART4_IRQHandler, %function
+LPUART4_IRQHandler:
+    ldr   r0,=LPUART4_DriverIRQHandler
+    bx    r0
+    .size LPUART4_IRQHandler, . - LPUART4_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPUART5_IRQHandler
+    .type LPUART5_IRQHandler, %function
+LPUART5_IRQHandler:
+    ldr   r0,=LPUART5_DriverIRQHandler
+    bx    r0
+    .size LPUART5_IRQHandler, . - LPUART5_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPUART6_IRQHandler
+    .type LPUART6_IRQHandler, %function
+LPUART6_IRQHandler:
+    ldr   r0,=LPUART6_DriverIRQHandler
+    bx    r0
+    .size LPUART6_IRQHandler, . - LPUART6_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak uSDHC1_IRQHandler
+    .type uSDHC1_IRQHandler, %function
+uSDHC1_IRQHandler:
+    ldr   r0,=uSDHC1_DriverIRQHandler
+    bx    r0
+    .size uSDHC1_IRQHandler, . - uSDHC1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak uSDHC2_IRQHandler
+    .type uSDHC2_IRQHandler, %function
+uSDHC2_IRQHandler:
+    ldr   r0,=uSDHC2_DriverIRQHandler
+    bx    r0
+    .size uSDHC2_IRQHandler, . - uSDHC2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_ERROR_IRQHandler
+    .type DMA3_ERROR_IRQHandler, %function
+DMA3_ERROR_IRQHandler:
+    mov   r0, #0
+    ldr   r1,=DMA3_DriverIRQHandler
+    bx    r1
+    .size DMA3_ERROR_IRQHandler, . - DMA3_ERROR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_0_IRQHandler
+    .type DMA3_0_IRQHandler, %function
+DMA3_0_IRQHandler:
+    mov   r0, #0
+    mov   r1, #0
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_0_IRQHandler, . - DMA3_0_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_1_IRQHandler
+    .type DMA3_1_IRQHandler, %function
+DMA3_1_IRQHandler:
+    mov   r0, #0
+    mov   r1, #1
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_1_IRQHandler, . - DMA3_1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_2_IRQHandler
+    .type DMA3_2_IRQHandler, %function
+DMA3_2_IRQHandler:
+    mov   r0, #0
+    mov   r1, #2
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_2_IRQHandler, . - DMA3_2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_3_IRQHandler
+    .type DMA3_3_IRQHandler, %function
+DMA3_3_IRQHandler:
+    mov   r0, #0
+    mov   r1, #3
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_3_IRQHandler, . - DMA3_3_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_4_IRQHandler
+    .type DMA3_4_IRQHandler, %function
+DMA3_4_IRQHandler:
+    mov   r0, #0
+    mov   r1, #4
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_4_IRQHandler, . - DMA3_4_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_5_IRQHandler
+    .type DMA3_5_IRQHandler, %function
+DMA3_5_IRQHandler:
+    mov   r0, #0
+    mov   r1, #5
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_5_IRQHandler, . - DMA3_5_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_6_IRQHandler
+    .type DMA3_6_IRQHandler, %function
+DMA3_6_IRQHandler:
+    mov   r0, #0
+    mov   r1, #6
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_6_IRQHandler, . - DMA3_6_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_7_IRQHandler
+    .type DMA3_7_IRQHandler, %function
+DMA3_7_IRQHandler:
+    mov   r0, #0
+    mov   r1, #7
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_7_IRQHandler, . - DMA3_7_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_8_IRQHandler
+    .type DMA3_8_IRQHandler, %function
+DMA3_8_IRQHandler:
+    mov   r0, #0
+    mov   r1, #8
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_8_IRQHandler, . - DMA3_8_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_9_IRQHandler
+    .type DMA3_9_IRQHandler, %function
+DMA3_9_IRQHandler:
+    mov   r0, #0
+    mov   r1, #9
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_9_IRQHandler, . - DMA3_9_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_10_IRQHandler
+    .type DMA3_10_IRQHandler, %function
+DMA3_10_IRQHandler:
+    mov   r0, #0
+    mov   r1, #10
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_10_IRQHandler, . - DMA3_10_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_11_IRQHandler
+    .type DMA3_11_IRQHandler, %function
+DMA3_11_IRQHandler:
+    mov   r0, #0
+    mov   r1, #11
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_11_IRQHandler, . - DMA3_11_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_12_IRQHandler
+    .type DMA3_12_IRQHandler, %function
+DMA3_12_IRQHandler:
+    mov   r0, #0
+    mov   r1, #12
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_12_IRQHandler, . - DMA3_12_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_13_IRQHandler
+    .type DMA3_13_IRQHandler, %function
+DMA3_13_IRQHandler:
+    mov   r0, #0
+    mov   r1, #13
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_13_IRQHandler, . - DMA3_13_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_14_IRQHandler
+    .type DMA3_14_IRQHandler, %function
+DMA3_14_IRQHandler:
+    mov   r0, #0
+    mov   r1, #14
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_14_IRQHandler, . - DMA3_14_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_15_IRQHandler
+    .type DMA3_15_IRQHandler, %function
+DMA3_15_IRQHandler:
+    mov   r0, #0
+    mov   r1, #15
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_15_IRQHandler, . - DMA3_15_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_16_IRQHandler
+    .type DMA3_16_IRQHandler, %function
+DMA3_16_IRQHandler:
+    mov   r0, #0
+    mov   r1, #16
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_16_IRQHandler, . - DMA3_16_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_17_IRQHandler
+    .type DMA3_17_IRQHandler, %function
+DMA3_17_IRQHandler:
+    mov   r0, #0
+    mov   r1, #17
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_17_IRQHandler, . - DMA3_17_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_18_IRQHandler
+    .type DMA3_18_IRQHandler, %function
+DMA3_18_IRQHandler:
+    mov   r0, #0
+    mov   r1, #18
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_18_IRQHandler, . - DMA3_18_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_19_IRQHandler
+    .type DMA3_19_IRQHandler, %function
+DMA3_19_IRQHandler:
+    mov   r0, #0
+    mov   r1, #19
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_19_IRQHandler, . - DMA3_19_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_20_IRQHandler
+    .type DMA3_20_IRQHandler, %function
+DMA3_20_IRQHandler:
+    mov   r0, #0
+    mov   r1, #20
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_20_IRQHandler, . - DMA3_20_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_21_IRQHandler
+    .type DMA3_21_IRQHandler, %function
+DMA3_21_IRQHandler:
+    mov   r0, #0
+    mov   r1, #21
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_21_IRQHandler, . - DMA3_21_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_22_IRQHandler
+    .type DMA3_22_IRQHandler, %function
+DMA3_22_IRQHandler:
+    mov   r0, #0
+    mov   r1, #22
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_22_IRQHandler, . - DMA3_22_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_23_IRQHandler
+    .type DMA3_23_IRQHandler, %function
+DMA3_23_IRQHandler:
+    mov   r0, #0
+    mov   r1, #23
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_23_IRQHandler, . - DMA3_23_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_24_IRQHandler
+    .type DMA3_24_IRQHandler, %function
+DMA3_24_IRQHandler:
+    mov   r0, #0
+    mov   r1, #24
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_24_IRQHandler, . - DMA3_24_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_25_IRQHandler
+    .type DMA3_25_IRQHandler, %function
+DMA3_25_IRQHandler:
+    mov   r0, #0
+    mov   r1, #25
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_25_IRQHandler, . - DMA3_25_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_26_IRQHandler
+    .type DMA3_26_IRQHandler, %function
+DMA3_26_IRQHandler:
+    mov   r0, #0
+    mov   r1, #26
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_26_IRQHandler, . - DMA3_26_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_27_IRQHandler
+    .type DMA3_27_IRQHandler, %function
+DMA3_27_IRQHandler:
+    mov   r0, #0
+    mov   r1, #27
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_27_IRQHandler, . - DMA3_27_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_28_IRQHandler
+    .type DMA3_28_IRQHandler, %function
+DMA3_28_IRQHandler:
+    mov   r0, #0
+    mov   r1, #28
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_28_IRQHandler, . - DMA3_28_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_29_IRQHandler
+    .type DMA3_29_IRQHandler, %function
+DMA3_29_IRQHandler:
+    mov   r0, #0
+    mov   r1, #29
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_29_IRQHandler, . - DMA3_29_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA3_30_IRQHandler
+    .type DMA3_30_IRQHandler, %function
+DMA3_30_IRQHandler:
+    mov   r0, #0
+    mov   r1, #30
+    ldr   r2,=DMA3_DriverIRQHandler
+    bx    r2
+    .size DMA3_30_IRQHandler, . - DMA3_30_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_ERROR_IRQHandler
+    .type DMA4_ERROR_IRQHandler, %function
+DMA4_ERROR_IRQHandler:
+    ldr   r0,=DMA4_ERROR_DriverIRQHandler
+    bx    r0
+    .size DMA4_ERROR_IRQHandler, . - DMA4_ERROR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_0_1_IRQHandler
+    .type DMA4_0_1_IRQHandler, %function
+DMA4_0_1_IRQHandler:
+    ldr   r0,=DMA4_0_1_DriverIRQHandler
+    bx    r0
+    .size DMA4_0_1_IRQHandler, . - DMA4_0_1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_2_3_IRQHandler
+    .type DMA4_2_3_IRQHandler, %function
+DMA4_2_3_IRQHandler:
+    ldr   r0,=DMA4_2_3_DriverIRQHandler
+    bx    r0
+    .size DMA4_2_3_IRQHandler, . - DMA4_2_3_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_4_5_IRQHandler
+    .type DMA4_4_5_IRQHandler, %function
+DMA4_4_5_IRQHandler:
+    ldr   r0,=DMA4_4_5_DriverIRQHandler
+    bx    r0
+    .size DMA4_4_5_IRQHandler, . - DMA4_4_5_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_6_7_IRQHandler
+    .type DMA4_6_7_IRQHandler, %function
+DMA4_6_7_IRQHandler:
+    ldr   r0,=DMA4_6_7_DriverIRQHandler
+    bx    r0
+    .size DMA4_6_7_IRQHandler, . - DMA4_6_7_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_8_9_IRQHandler
+    .type DMA4_8_9_IRQHandler, %function
+DMA4_8_9_IRQHandler:
+    ldr   r0,=DMA4_8_9_DriverIRQHandler
+    bx    r0
+    .size DMA4_8_9_IRQHandler, . - DMA4_8_9_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_10_11_IRQHandler
+    .type DMA4_10_11_IRQHandler, %function
+DMA4_10_11_IRQHandler:
+    ldr   r0,=DMA4_10_11_DriverIRQHandler
+    bx    r0
+    .size DMA4_10_11_IRQHandler, . - DMA4_10_11_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_12_13_IRQHandler
+    .type DMA4_12_13_IRQHandler, %function
+DMA4_12_13_IRQHandler:
+    ldr   r0,=DMA4_12_13_DriverIRQHandler
+    bx    r0
+    .size DMA4_12_13_IRQHandler, . - DMA4_12_13_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_14_15_IRQHandler
+    .type DMA4_14_15_IRQHandler, %function
+DMA4_14_15_IRQHandler:
+    ldr   r0,=DMA4_14_15_DriverIRQHandler
+    bx    r0
+    .size DMA4_14_15_IRQHandler, . - DMA4_14_15_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_16_17_IRQHandler
+    .type DMA4_16_17_IRQHandler, %function
+DMA4_16_17_IRQHandler:
+    ldr   r0,=DMA4_16_17_DriverIRQHandler
+    bx    r0
+    .size DMA4_16_17_IRQHandler, . - DMA4_16_17_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_18_19_IRQHandler
+    .type DMA4_18_19_IRQHandler, %function
+DMA4_18_19_IRQHandler:
+    ldr   r0,=DMA4_18_19_DriverIRQHandler
+    bx    r0
+    .size DMA4_18_19_IRQHandler, . - DMA4_18_19_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_20_21_IRQHandler
+    .type DMA4_20_21_IRQHandler, %function
+DMA4_20_21_IRQHandler:
+    ldr   r0,=DMA4_20_21_DriverIRQHandler
+    bx    r0
+    .size DMA4_20_21_IRQHandler, . - DMA4_20_21_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_22_23_IRQHandler
+    .type DMA4_22_23_IRQHandler, %function
+DMA4_22_23_IRQHandler:
+    ldr   r0,=DMA4_22_23_DriverIRQHandler
+    bx    r0
+    .size DMA4_22_23_IRQHandler, . - DMA4_22_23_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_24_25_IRQHandler
+    .type DMA4_24_25_IRQHandler, %function
+DMA4_24_25_IRQHandler:
+    ldr   r0,=DMA4_24_25_DriverIRQHandler
+    bx    r0
+    .size DMA4_24_25_IRQHandler, . - DMA4_24_25_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_26_27_IRQHandler
+    .type DMA4_26_27_IRQHandler, %function
+DMA4_26_27_IRQHandler:
+    ldr   r0,=DMA4_26_27_DriverIRQHandler
+    bx    r0
+    .size DMA4_26_27_IRQHandler, . - DMA4_26_27_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_28_29_IRQHandler
+    .type DMA4_28_29_IRQHandler, %function
+DMA4_28_29_IRQHandler:
+    ldr   r0,=DMA4_28_29_DriverIRQHandler
+    bx    r0
+    .size DMA4_28_29_IRQHandler, . - DMA4_28_29_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_30_31_IRQHandler
+    .type DMA4_30_31_IRQHandler, %function
+DMA4_30_31_IRQHandler:
+    ldr   r0,=DMA4_30_31_DriverIRQHandler
+    bx    r0
+    .size DMA4_30_31_IRQHandler, . - DMA4_30_31_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_32_33_IRQHandler
+    .type DMA4_32_33_IRQHandler, %function
+DMA4_32_33_IRQHandler:
+    ldr   r0,=DMA4_32_33_DriverIRQHandler
+    bx    r0
+    .size DMA4_32_33_IRQHandler, . - DMA4_32_33_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_34_35_IRQHandler
+    .type DMA4_34_35_IRQHandler, %function
+DMA4_34_35_IRQHandler:
+    ldr   r0,=DMA4_34_35_DriverIRQHandler
+    bx    r0
+    .size DMA4_34_35_IRQHandler, . - DMA4_34_35_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_36_37_IRQHandler
+    .type DMA4_36_37_IRQHandler, %function
+DMA4_36_37_IRQHandler:
+    ldr   r0,=DMA4_36_37_DriverIRQHandler
+    bx    r0
+    .size DMA4_36_37_IRQHandler, . - DMA4_36_37_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_38_39_IRQHandler
+    .type DMA4_38_39_IRQHandler, %function
+DMA4_38_39_IRQHandler:
+    ldr   r0,=DMA4_38_39_DriverIRQHandler
+    bx    r0
+    .size DMA4_38_39_IRQHandler, . - DMA4_38_39_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_40_41_IRQHandler
+    .type DMA4_40_41_IRQHandler, %function
+DMA4_40_41_IRQHandler:
+    ldr   r0,=DMA4_40_41_DriverIRQHandler
+    bx    r0
+    .size DMA4_40_41_IRQHandler, . - DMA4_40_41_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_42_43_IRQHandler
+    .type DMA4_42_43_IRQHandler, %function
+DMA4_42_43_IRQHandler:
+    ldr   r0,=DMA4_42_43_DriverIRQHandler
+    bx    r0
+    .size DMA4_42_43_IRQHandler, . - DMA4_42_43_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_44_45_IRQHandler
+    .type DMA4_44_45_IRQHandler, %function
+DMA4_44_45_IRQHandler:
+    ldr   r0,=DMA4_44_45_DriverIRQHandler
+    bx    r0
+    .size DMA4_44_45_IRQHandler, . - DMA4_44_45_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_46_47_IRQHandler
+    .type DMA4_46_47_IRQHandler, %function
+DMA4_46_47_IRQHandler:
+    ldr   r0,=DMA4_46_47_DriverIRQHandler
+    bx    r0
+    .size DMA4_46_47_IRQHandler, . - DMA4_46_47_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_48_49_IRQHandler
+    .type DMA4_48_49_IRQHandler, %function
+DMA4_48_49_IRQHandler:
+    ldr   r0,=DMA4_48_49_DriverIRQHandler
+    bx    r0
+    .size DMA4_48_49_IRQHandler, . - DMA4_48_49_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_50_51_IRQHandler
+    .type DMA4_50_51_IRQHandler, %function
+DMA4_50_51_IRQHandler:
+    ldr   r0,=DMA4_50_51_DriverIRQHandler
+    bx    r0
+    .size DMA4_50_51_IRQHandler, . - DMA4_50_51_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_52_53_IRQHandler
+    .type DMA4_52_53_IRQHandler, %function
+DMA4_52_53_IRQHandler:
+    ldr   r0,=DMA4_52_53_DriverIRQHandler
+    bx    r0
+    .size DMA4_52_53_IRQHandler, . - DMA4_52_53_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_54_55_IRQHandler
+    .type DMA4_54_55_IRQHandler, %function
+DMA4_54_55_IRQHandler:
+    ldr   r0,=DMA4_54_55_DriverIRQHandler
+    bx    r0
+    .size DMA4_54_55_IRQHandler, . - DMA4_54_55_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_56_57_IRQHandler
+    .type DMA4_56_57_IRQHandler, %function
+DMA4_56_57_IRQHandler:
+    ldr   r0,=DMA4_56_57_DriverIRQHandler
+    bx    r0
+    .size DMA4_56_57_IRQHandler, . - DMA4_56_57_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_58_59_IRQHandler
+    .type DMA4_58_59_IRQHandler, %function
+DMA4_58_59_IRQHandler:
+    ldr   r0,=DMA4_58_59_DriverIRQHandler
+    bx    r0
+    .size DMA4_58_59_IRQHandler, . - DMA4_58_59_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_60_61_IRQHandler
+    .type DMA4_60_61_IRQHandler, %function
+DMA4_60_61_IRQHandler:
+    ldr   r0,=DMA4_60_61_DriverIRQHandler
+    bx    r0
+    .size DMA4_60_61_IRQHandler, . - DMA4_60_61_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak DMA4_62_63_IRQHandler
+    .type DMA4_62_63_IRQHandler, %function
+DMA4_62_63_IRQHandler:
+    ldr   r0,=DMA4_62_63_DriverIRQHandler
+    bx    r0
+    .size DMA4_62_63_IRQHandler, . - DMA4_62_63_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SAI2_IRQHandler
+    .type SAI2_IRQHandler, %function
+SAI2_IRQHandler:
+    ldr   r0,=SAI2_DriverIRQHandler
+    bx    r0
+    .size SAI2_IRQHandler, . - SAI2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak SAI3_IRQHandler
+    .type SAI3_IRQHandler, %function
+SAI3_IRQHandler:
+    ldr   r0,=SAI3_DriverIRQHandler
+    bx    r0
+    .size SAI3_IRQHandler, . - SAI3_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_MAC0_Rx_Tx_Done1_IRQHandler
+    .type ENET_MAC0_Rx_Tx_Done1_IRQHandler, %function
+ENET_MAC0_Rx_Tx_Done1_IRQHandler:
+    ldr   r0,=ENET_MAC0_Rx_Tx_Done1_DriverIRQHandler
+    bx    r0
+    .size ENET_MAC0_Rx_Tx_Done1_IRQHandler, . - ENET_MAC0_Rx_Tx_Done1_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_MAC0_Rx_Tx_Done2_IRQHandler
+    .type ENET_MAC0_Rx_Tx_Done2_IRQHandler, %function
+ENET_MAC0_Rx_Tx_Done2_IRQHandler:
+    ldr   r0,=ENET_MAC0_Rx_Tx_Done2_DriverIRQHandler
+    bx    r0
+    .size ENET_MAC0_Rx_Tx_Done2_IRQHandler, . - ENET_MAC0_Rx_Tx_Done2_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_IRQHandler
+    .type ENET_IRQHandler, %function
+ENET_IRQHandler:
+    ldr   r0,=ENET_DriverIRQHandler
+    bx    r0
+    .size ENET_IRQHandler, . - ENET_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_1588_IRQHandler
+    .type ENET_1588_IRQHandler, %function
+ENET_1588_IRQHandler:
+    ldr   r0,=ENET_1588_DriverIRQHandler
+    bx    r0
+    .size ENET_1588_IRQHandler, . - ENET_1588_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak ENET_QOS_IRQHandler
+    .type ENET_QOS_IRQHandler, %function
+ENET_QOS_IRQHandler:
+    ldr   r0,=ENET_QOS_DriverIRQHandler
+    bx    r0
+    .size ENET_QOS_IRQHandler, . - ENET_QOS_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPSPI5_IRQHandler
+    .type LPSPI5_IRQHandler, %function
+LPSPI5_IRQHandler:
+    ldr   r0,=LPSPI5_DriverIRQHandler
+    bx    r0
+    .size LPSPI5_IRQHandler, . - LPSPI5_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPSPI6_IRQHandler
+    .type LPSPI6_IRQHandler, %function
+LPSPI6_IRQHandler:
+    ldr   r0,=LPSPI6_DriverIRQHandler
+    bx    r0
+    .size LPSPI6_IRQHandler, . - LPSPI6_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPSPI7_IRQHandler
+    .type LPSPI7_IRQHandler, %function
+LPSPI7_IRQHandler:
+    ldr   r0,=LPSPI7_DriverIRQHandler
+    bx    r0
+    .size LPSPI7_IRQHandler, . - LPSPI7_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPSPI8_IRQHandler
+    .type LPSPI8_IRQHandler, %function
+LPSPI8_IRQHandler:
+    ldr   r0,=LPSPI8_DriverIRQHandler
+    bx    r0
+    .size LPSPI8_IRQHandler, . - LPSPI8_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPI2C5_IRQHandler
+    .type LPI2C5_IRQHandler, %function
+LPI2C5_IRQHandler:
+    ldr   r0,=LPI2C5_DriverIRQHandler
+    bx    r0
+    .size LPI2C5_IRQHandler, . - LPI2C5_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPI2C6_IRQHandler
+    .type LPI2C6_IRQHandler, %function
+LPI2C6_IRQHandler:
+    ldr   r0,=LPI2C6_DriverIRQHandler
+    bx    r0
+    .size LPI2C6_IRQHandler, . - LPI2C6_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPI2C7_IRQHandler
+    .type LPI2C7_IRQHandler, %function
+LPI2C7_IRQHandler:
+    ldr   r0,=LPI2C7_DriverIRQHandler
+    bx    r0
+    .size LPI2C7_IRQHandler, . - LPI2C7_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPI2C8_IRQHandler
+    .type LPI2C8_IRQHandler, %function
+LPI2C8_IRQHandler:
+    ldr   r0,=LPI2C8_DriverIRQHandler
+    bx    r0
+    .size LPI2C8_IRQHandler, . - LPI2C8_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak PDM_HWVAD_ERROR_IRQHandler
+    .type PDM_HWVAD_ERROR_IRQHandler, %function
+PDM_HWVAD_ERROR_IRQHandler:
+    ldr   r0,=PDM_HWVAD_ERROR_DriverIRQHandler
+    bx    r0
+    .size PDM_HWVAD_ERROR_IRQHandler, . - PDM_HWVAD_ERROR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak PDM_HWVAD_EVENT_IRQHandler
+    .type PDM_HWVAD_EVENT_IRQHandler, %function
+PDM_HWVAD_EVENT_IRQHandler:
+    ldr   r0,=PDM_HWVAD_EVENT_DriverIRQHandler
+    bx    r0
+    .size PDM_HWVAD_EVENT_IRQHandler, . - PDM_HWVAD_EVENT_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak PDM_ERROR_IRQHandler
+    .type PDM_ERROR_IRQHandler, %function
+PDM_ERROR_IRQHandler:
+    ldr   r0,=PDM_ERROR_DriverIRQHandler
+    bx    r0
+    .size PDM_ERROR_IRQHandler, . - PDM_ERROR_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak PDM_EVENT_IRQHandler
+    .type PDM_EVENT_IRQHandler, %function
+PDM_EVENT_IRQHandler:
+    ldr   r0,=PDM_EVENT_DriverIRQHandler
+    bx    r0
+    .size PDM_EVENT_IRQHandler, . - PDM_EVENT_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak uSDHC3_IRQHandler
+    .type uSDHC3_IRQHandler, %function
+uSDHC3_IRQHandler:
+    ldr   r0,=uSDHC3_DriverIRQHandler
+    bx    r0
+    .size uSDHC3_IRQHandler, . - uSDHC3_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPUART7_IRQHandler
+    .type LPUART7_IRQHandler, %function
+LPUART7_IRQHandler:
+    ldr   r0,=LPUART7_DriverIRQHandler
+    bx    r0
+    .size LPUART7_IRQHandler, . - LPUART7_IRQHandler
+
+    .align 1
+    .thumb_func
+    .weak LPUART8_IRQHandler
+    .type LPUART8_IRQHandler, %function
+LPUART8_IRQHandler:
+    ldr   r0,=LPUART8_DriverIRQHandler
+    bx    r0
+    .size LPUART8_IRQHandler, . - LPUART8_IRQHandler
+
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+    .macro def_irq_handler  handler_name
+    .weak \handler_name
+    .set  \handler_name, DefaultISR
+    .endm
+
+/* Exception Handlers */
+    def_irq_handler    MemManage_Handler
+    def_irq_handler    BusFault_Handler
+    def_irq_handler    UsageFault_Handler
+    def_irq_handler    SecureFault_Handler
+    def_irq_handler    DebugMon_Handler
+    def_irq_handler    Reserved16_IRQHandler
+    def_irq_handler    Reserved17_IRQHandler
+    def_irq_handler    Reserved18_IRQHandler
+    def_irq_handler    Reserved19_IRQHandler
+    def_irq_handler    Reserved20_IRQHandler
+    def_irq_handler    Reserved21_IRQHandler
+    def_irq_handler    Reserved22_IRQHandler
+    def_irq_handler    Reserved23_IRQHandler
+    def_irq_handler    CAN1_DriverIRQHandler
+    def_irq_handler    CAN1_ERROR_DriverIRQHandler
+    def_irq_handler    Reserved26_IRQHandler
+    def_irq_handler    Reserved27_IRQHandler
+    def_irq_handler    I3C1_DriverIRQHandler
+    def_irq_handler    LPI2C1_DriverIRQHandler
+    def_irq_handler    LPI2C2_DriverIRQHandler
+    def_irq_handler    LPIT1_IRQHandler
+    def_irq_handler    LPSPI1_DriverIRQHandler
+    def_irq_handler    LPSPI2_DriverIRQHandler
+    def_irq_handler    LPTMR1_IRQHandler
+    def_irq_handler    LPUART1_DriverIRQHandler
+    def_irq_handler    LPUART2_DriverIRQHandler
+    def_irq_handler    MU1_A_IRQHandler
+    def_irq_handler    MU1_B_IRQHandler
+    def_irq_handler    MU2_A_IRQHandler
+    def_irq_handler    MU2_B_IRQHandler
+    def_irq_handler    Reserved41_IRQHandler
+    def_irq_handler    Reserved42_IRQHandler
+    def_irq_handler    Reserved43_IRQHandler
+    def_irq_handler    Reserved44_IRQHandler
+    def_irq_handler    Reserved45_IRQHandler
+    def_irq_handler    Reserved46_IRQHandler
+    def_irq_handler    Reserved47_IRQHandler
+    def_irq_handler    Reserved48_IRQHandler
+    def_irq_handler    Reserved49_IRQHandler
+    def_irq_handler    Reserved50_IRQHandler
+    def_irq_handler    Reserved51_IRQHandler
+    def_irq_handler    TPM1_IRQHandler
+    def_irq_handler    TPM2_IRQHandler
+    def_irq_handler    WDOG1_IRQHandler
+    def_irq_handler    WDOG2_IRQHandler
+    def_irq_handler    TRDC_IRQHandler
+    def_irq_handler    Reserved57_IRQHandler
+    def_irq_handler    Reserved58_IRQHandler
+    def_irq_handler    Reserved59_IRQHandler
+    def_irq_handler    Reserved60_IRQHandler
+    def_irq_handler    SAI1_DriverIRQHandler
+    def_irq_handler    Reserved62_IRQHandler
+    def_irq_handler    Reserved63_IRQHandler
+    def_irq_handler    Reserved64_IRQHandler
+    def_irq_handler    Reserved65_IRQHandler
+    def_irq_handler    Reserved66_IRQHandler
+    def_irq_handler    CAN2_DriverIRQHandler
+    def_irq_handler    CAN2_ERROR_DriverIRQHandler
+    def_irq_handler    FLEXIO1_DriverIRQHandler
+    def_irq_handler    FLEXIO2_DriverIRQHandler
+    def_irq_handler    FlexSPI1_DriverIRQHandler
+    def_irq_handler    Reserved72_IRQHandler
+    def_irq_handler    Reserved73_IRQHandler
+    def_irq_handler    Reserved74_IRQHandler
+    def_irq_handler    Reserved75_IRQHandler
+    def_irq_handler    Reserved76_IRQHandler
+    def_irq_handler    I3C2_DriverIRQHandler
+    def_irq_handler    LPI2C3_DriverIRQHandler
+    def_irq_handler    LPI2C4_DriverIRQHandler
+    def_irq_handler    LPIT2_IRQHandler
+    def_irq_handler    LPSPI3_DriverIRQHandler
+    def_irq_handler    LPSPI4_DriverIRQHandler
+    def_irq_handler    LPTMR2_IRQHandler
+    def_irq_handler    LPUART3_DriverIRQHandler
+    def_irq_handler    LPUART4_DriverIRQHandler
+    def_irq_handler    LPUART5_DriverIRQHandler
+    def_irq_handler    LPUART6_DriverIRQHandler
+    def_irq_handler    Reserved88_IRQHandler
+    def_irq_handler    Reserved89_IRQHandler
+    def_irq_handler    Reserved90_IRQHandler
+    def_irq_handler    TPM3_IRQHandler
+    def_irq_handler    TPM4_IRQHandler
+    def_irq_handler    TPM5_IRQHandler
+    def_irq_handler    TPM6_IRQHandler
+    def_irq_handler    WDOG3_IRQHandler
+    def_irq_handler    WDOG4_IRQHandler
+    def_irq_handler    WDOG5_IRQHandler
+    def_irq_handler    Reserved98_IRQHandler
+    def_irq_handler    Reserved99_IRQHandler
+    def_irq_handler    Reserved100_IRQHandler
+    def_irq_handler    Reserved101_IRQHandler
+    def_irq_handler    uSDHC1_DriverIRQHandler
+    def_irq_handler    uSDHC2_DriverIRQHandler
+    def_irq_handler    Reserved104_IRQHandler
+    def_irq_handler    Reserved105_IRQHandler
+    def_irq_handler    Reserved106_IRQHandler
+    def_irq_handler    Reserved107_IRQHandler
+    def_irq_handler    Reserved108_IRQHandler
+    def_irq_handler    Reserved109_IRQHandler
+    def_irq_handler    DMA3_DriverIRQHandler
+    def_irq_handler    Reserved142_IRQHandler
+    def_irq_handler    DMA4_ERROR_DriverIRQHandler
+    def_irq_handler    DMA4_0_1_DriverIRQHandler
+    def_irq_handler    DMA4_2_3_DriverIRQHandler
+    def_irq_handler    DMA4_4_5_DriverIRQHandler
+    def_irq_handler    DMA4_6_7_DriverIRQHandler
+    def_irq_handler    DMA4_8_9_DriverIRQHandler
+    def_irq_handler    DMA4_10_11_DriverIRQHandler
+    def_irq_handler    DMA4_12_13_DriverIRQHandler
+    def_irq_handler    DMA4_14_15_DriverIRQHandler
+    def_irq_handler    DMA4_16_17_DriverIRQHandler
+    def_irq_handler    DMA4_18_19_DriverIRQHandler
+    def_irq_handler    DMA4_20_21_DriverIRQHandler
+    def_irq_handler    DMA4_22_23_DriverIRQHandler
+    def_irq_handler    DMA4_24_25_DriverIRQHandler
+    def_irq_handler    DMA4_26_27_DriverIRQHandler
+    def_irq_handler    DMA4_28_29_DriverIRQHandler
+    def_irq_handler    DMA4_30_31_DriverIRQHandler
+    def_irq_handler    DMA4_32_33_DriverIRQHandler
+    def_irq_handler    DMA4_34_35_DriverIRQHandler
+    def_irq_handler    DMA4_36_37_DriverIRQHandler
+    def_irq_handler    DMA4_38_39_DriverIRQHandler
+    def_irq_handler    DMA4_40_41_DriverIRQHandler
+    def_irq_handler    DMA4_42_43_DriverIRQHandler
+    def_irq_handler    DMA4_44_45_DriverIRQHandler
+    def_irq_handler    DMA4_46_47_DriverIRQHandler
+    def_irq_handler    DMA4_48_49_DriverIRQHandler
+    def_irq_handler    DMA4_50_51_DriverIRQHandler
+    def_irq_handler    DMA4_52_53_DriverIRQHandler
+    def_irq_handler    DMA4_54_55_DriverIRQHandler
+    def_irq_handler    DMA4_56_57_DriverIRQHandler
+    def_irq_handler    DMA4_58_59_DriverIRQHandler
+    def_irq_handler    DMA4_60_61_DriverIRQHandler
+    def_irq_handler    DMA4_62_63_DriverIRQHandler
+    def_irq_handler    Reserved176_IRQHandler
+    def_irq_handler    Reserved177_IRQHandler
+    def_irq_handler    Reserved178_IRQHandler
+    def_irq_handler    Reserved179_IRQHandler
+    def_irq_handler    Reserved180_IRQHandler
+    def_irq_handler    Reserved181_IRQHandler
+    def_irq_handler    Reserved182_IRQHandler
+    def_irq_handler    Reserved183_IRQHandler
+    def_irq_handler    Reserved184_IRQHandler
+    def_irq_handler    Reserved185_IRQHandler
+    def_irq_handler    SAI2_DriverIRQHandler
+    def_irq_handler    SAI3_DriverIRQHandler
+    def_irq_handler    ISI_IRQHandler
+    def_irq_handler    Reserved189_IRQHandler
+    def_irq_handler    Reserved190_IRQHandler
+    def_irq_handler    CSI_IRQHandler
+    def_irq_handler    Reserved192_IRQHandler
+    def_irq_handler    DSI_IRQHandler
+    def_irq_handler    Reserved194_IRQHandler
+    def_irq_handler    ENET_MAC0_Rx_Tx_Done1_DriverIRQHandler
+    def_irq_handler    ENET_MAC0_Rx_Tx_Done2_DriverIRQHandler
+    def_irq_handler    ENET_DriverIRQHandler
+    def_irq_handler    ENET_1588_DriverIRQHandler
+    def_irq_handler    ENET_QOS_PMT_IRQHandler
+    def_irq_handler    ENET_QOS_DriverIRQHandler
+    def_irq_handler    Reserved201_IRQHandler
+    def_irq_handler    Reserved202_IRQHandler
+    def_irq_handler    Reserved203_IRQHandler
+    def_irq_handler    Reserved204_IRQHandler
+    def_irq_handler    Reserved205_IRQHandler
+    def_irq_handler    Reserved206_IRQHandler
+    def_irq_handler    LPSPI5_DriverIRQHandler
+    def_irq_handler    LPSPI6_DriverIRQHandler
+    def_irq_handler    LPSPI7_DriverIRQHandler
+    def_irq_handler    LPSPI8_DriverIRQHandler
+    def_irq_handler    LPI2C5_DriverIRQHandler
+    def_irq_handler    LPI2C6_DriverIRQHandler
+    def_irq_handler    LPI2C7_DriverIRQHandler
+    def_irq_handler    LPI2C8_DriverIRQHandler
+    def_irq_handler    PDM_HWVAD_ERROR_DriverIRQHandler
+    def_irq_handler    PDM_HWVAD_EVENT_DriverIRQHandler
+    def_irq_handler    PDM_ERROR_DriverIRQHandler
+    def_irq_handler    PDM_EVENT_DriverIRQHandler
+    def_irq_handler    Reserved219_IRQHandler
+    def_irq_handler    Reserved220_IRQHandler
+    def_irq_handler    uSDHC3_DriverIRQHandler
+    def_irq_handler    Reserved222_IRQHandler
+    def_irq_handler    Reserved223_IRQHandler
+    def_irq_handler    Reserved224_IRQHandler
+    def_irq_handler    Reserved225_IRQHandler
+    def_irq_handler    LPUART7_DriverIRQHandler
+    def_irq_handler    LPUART8_DriverIRQHandler
+    def_irq_handler    Reserved228_IRQHandler
+    def_irq_handler    Reserved229_IRQHandler
+    def_irq_handler    Reserved230_IRQHandler
+    def_irq_handler    Reserved231_IRQHandler
+    def_irq_handler    Reserved232_IRQHandler
+    def_irq_handler    Reserved233_IRQHandler
+    def_irq_handler    Reserved234_IRQHandler
+    def_irq_handler    Reserved235_IRQHandler
+    def_irq_handler    Reserved236_IRQHandler
+    def_irq_handler    Reserved237_IRQHandler
+    def_irq_handler    Reserved238_IRQHandler
+    def_irq_handler    Reserved239_IRQHandler
+    def_irq_handler    Reserved240_IRQHandler
+    def_irq_handler    Reserved241_IRQHandler
+    def_irq_handler    Reserved242_IRQHandler
+    def_irq_handler    Reserved243_IRQHandler
+    def_irq_handler    Reserved244_IRQHandler
+    def_irq_handler    Reserved245_IRQHandler
+    def_irq_handler    Reserved246_IRQHandler
+    def_irq_handler    Reserved247_IRQHandler
+    def_irq_handler    Reserved248_IRQHandler
+    def_irq_handler    Reserved249_IRQHandler
+    def_irq_handler    Reserved250_IRQHandler
+    def_irq_handler    Reserved251_IRQHandler
+    def_irq_handler    Reserved252_IRQHandler
+    def_irq_handler    Reserved253_IRQHandler
+    def_irq_handler    Reserved254_IRQHandler
+    def_irq_handler    Reserved255_IRQHandler
+    def_irq_handler    Reserved256_IRQHandler
+    def_irq_handler    Reserved257_IRQHandler
+    def_irq_handler    Reserved258_IRQHandler
+    def_irq_handler    Reserved259_IRQHandler
+    def_irq_handler    Reserved260_IRQHandler
+    def_irq_handler    Reserved261_IRQHandler
+    def_irq_handler    Reserved262_IRQHandler
+    def_irq_handler    Reserved263_IRQHandler
+    def_irq_handler    Reserved264_IRQHandler
+    def_irq_handler    Reserved265_IRQHandler
+    def_irq_handler    Reserved266_IRQHandler
+    def_irq_handler    Reserved267_IRQHandler
+    def_irq_handler    Reserved268_IRQHandler
+    def_irq_handler    Reserved269_IRQHandler
+    def_irq_handler    Reserved270_IRQHandler
+    def_irq_handler    Reserved271_IRQHandler
+    def_irq_handler    Reserved272_IRQHandler
+    def_irq_handler    Reserved273_IRQHandler
+    def_irq_handler    Reserved274_IRQHandler
+    def_irq_handler    Reserved275_IRQHandler
+    def_irq_handler    Reserved276_IRQHandler
+    def_irq_handler    Reserved277_IRQHandler
+    def_irq_handler    Reserved278_IRQHandler
+    def_irq_handler    Reserved279_IRQHandler
+    def_irq_handler    Reserved280_IRQHandler
+    def_irq_handler    Reserved281_IRQHandler
+    def_irq_handler    Reserved282_IRQHandler
+    def_irq_handler    Reserved283_IRQHandler
+    def_irq_handler    Reserved284_IRQHandler
+
+    .end

--- a/devices/MIMX9352/system_MIMX9352_ca55.c
+++ b/devices/MIMX9352/system_MIMX9352_ca55.c
@@ -1,0 +1,85 @@
+/*
+** ###################################################################
+**     Processors:          MIMX9352AVTXM_ca55
+**                          MIMX9352CVUXK_ca55
+**                          MIMX9352DVUXM_ca55
+**
+**     Reference manual:    IMX93RM, Internal, November. 2021
+**     Version:             rev. 1.0, 2021-11-16
+**     Build:               b221019
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2022 NXP
+**     All rights reserved.
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+**     Revisions:
+**     - rev. 1.0 (2021-11-16)
+**         Initial version.
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MIMX9352_ca55
+ * @version 1.0
+ * @date 2021-11-16
+ * @brief Device specific configuration file for MIMX9352_ca55 (implementation
+ *        file)
+ *
+ * Provides a system configuration function and a global variable that contains
+ * the system frequency. It configures the device and initializes the oscillator
+ * (PLL) that is part of the microcontroller device.
+ */
+
+#include <stdint.h>
+#include "fsl_device_registers.h"
+
+
+
+
+
+/* ----------------------------------------------------------------------------
+   -- Core clock
+   ---------------------------------------------------------------------------- */
+
+uint32_t SystemCoreClock = DEFAULT_SYSTEM_CLOCK;
+
+/* ----------------------------------------------------------------------------
+   -- SystemInit()
+   ---------------------------------------------------------------------------- */
+
+void SystemInit (void) {
+#if ((__FPU_PRESENT == 1) && (__FPU_USED == 1))
+  SCB->CPACR |= ((3UL << 10*2) | (3UL << 11*2));    /* set CP10, CP11 Full Access */
+#endif /* ((__FPU_PRESENT == 1) && (__FPU_USED == 1)) */
+
+
+  SystemInitHook();
+}
+
+/* ----------------------------------------------------------------------------
+   -- SystemCoreClockUpdate()
+   ---------------------------------------------------------------------------- */
+
+void SystemCoreClockUpdate (void) {
+
+
+}
+
+/* ----------------------------------------------------------------------------
+   -- SystemInitHook()
+   ---------------------------------------------------------------------------- */
+
+__attribute__ ((weak)) void SystemInitHook (void) {
+  /* Void implementation of the weak function. */
+}

--- a/devices/MIMX9352/system_MIMX9352_ca55.h
+++ b/devices/MIMX9352/system_MIMX9352_ca55.h
@@ -1,0 +1,100 @@
+/*
+** ###################################################################
+**     Processors:          MIMX9352AVTXM_ca55
+**                          MIMX9352CVUXK_ca55
+**                          MIMX9352DVUXM_ca55
+**
+**     Reference manual:    IMX93RM, Internal, November. 2021
+**     Version:             rev. 1.0, 2021-11-16
+**     Build:               b221019
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2022 NXP
+**     All rights reserved.
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+**     Revisions:
+**     - rev. 1.0 (2021-11-16)
+**         Initial version.
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MIMX9352_ca55
+ * @version 1.0
+ * @date 2021-11-16
+ * @brief Device specific configuration file for MIMX9352_ca55 (header file)
+ *
+ * Provides a system configuration function and a global variable that contains
+ * the system frequency. It configures the device and initializes the oscillator
+ * (PLL) that is part of the microcontroller device.
+ */
+
+#ifndef _SYSTEM_MIMX9352_ca55_H_
+#define _SYSTEM_MIMX9352_ca55_H_                 /**< Symbol preventing repeated inclusion */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+
+
+
+/**
+ * @brief System clock frequency (core clock)
+ *
+ * The system clock frequency supplied to the SysTick timer and the processor
+ * core clock. This variable can be used by the user application to setup the
+ * SysTick timer or configure other parameters. It may also be used by debugger to
+ * query the frequency of the debug timer or configure the trace clock speed
+ * SystemCoreClock is initialized with a correct predefined value.
+ */
+extern uint32_t SystemCoreClock;
+
+/**
+ * @brief Setup the microcontroller system.
+ *
+ * Typically this function configures the oscillator (PLL) that is part of the
+ * microcontroller device. For systems with variable clock speed it also updates
+ * the variable SystemCoreClock. SystemInit is called from startup_device file.
+ */
+void SystemInit (void);
+
+/**
+ * @brief Updates the SystemCoreClock variable.
+ *
+ * It must be called whenever the core clock is changed during program
+ * execution. SystemCoreClockUpdate() evaluates the clock register settings and calculates
+ * the current core clock.
+ */
+void SystemCoreClockUpdate (void);
+
+/**
+ * @brief SystemInit function hook.
+ *
+ * This weak function allows to call specific initialization code during the
+ * SystemInit() execution.This can be used when an application specific code needs
+ * to be called as close to the reset entry as possible (for example the Multicore
+ * Manager MCMGR_EarlyInit() function call).
+ * NOTE: No global r/w variables can be used in this hook function because the
+ * initialization of these variables happens after this function.
+ */
+void SystemInitHook (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* _SYSTEM_MIMX9352_ca55_H_ */

--- a/devices/MIMX9352/system_MIMX9352_cm33.c
+++ b/devices/MIMX9352/system_MIMX9352_cm33.c
@@ -1,0 +1,67 @@
+/*
+** ###################################################################
+**     Processors:          MIMX9352CVUXK_cm33
+**                          MIMX9352DVUXM_cm33
+**
+**     Compilers:           GNU C Compiler
+**                          IAR ANSI C/C++ Compiler for ARM
+**                          Keil ARM C/C++ Compiler
+**
+**     Reference manual:    IMX93RM, Internal, November. 2021
+**     Version:             rev. 1.0, 2021-11-16
+**     Build:               b220830
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2022 NXP
+**     All rights reserved.
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+**     Revisions:
+**     - rev. 1.0 (2021-11-16)
+**         Initial version.
+**
+** ###################################################################
+*/
+
+
+#include "system_MIMX9352_cm33.h"
+
+/* ----------------------------------------------------------------------------
+   -- Core clock
+   ---------------------------------------------------------------------------- */
+uint32_t SystemCoreClock = DEFAULT_SYSTEM_CLOCK;
+
+/* ----------------------------------------------------------------------------
+   -- SystemInit()
+   ---------------------------------------------------------------------------- */
+
+void SystemInit(void)
+{
+    SystemInitHook();
+}
+
+/* ----------------------------------------------------------------------------
+   -- SystemInitHook()
+   ---------------------------------------------------------------------------- */
+
+__attribute__((weak)) void SystemInitHook(void)
+{
+    /* Void implementation of the weak function. */
+}
+
+/* ----------------------------------------------------------------------------
+   -- SystemCoreClockUpdate()
+   ---------------------------------------------------------------------------- */
+
+void SystemCoreClockUpdate(void)
+{
+}

--- a/devices/MIMX9352/system_MIMX9352_cm33.h
+++ b/devices/MIMX9352/system_MIMX9352_cm33.h
@@ -1,0 +1,92 @@
+/*
+** ###################################################################
+**     Processors:          MIMX9352CVUXK_cm33
+**                          MIMX9352DVUXM_cm33
+**
+**     Compilers:           GNU C Compiler
+**                          IAR ANSI C/C++ Compiler for ARM
+**                          Keil ARM C/C++ Compiler
+**
+**     Reference manual:    IMX93RM, Internal, November. 2021
+**     Version:             rev. 1.0, 2021-11-16
+**     Build:               b220830
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright 2016 Freescale Semiconductor, Inc.
+**     Copyright 2016-2022 NXP
+**     All rights reserved.
+**
+**     SPDX-License-Identifier: BSD-3-Clause
+**
+**     http:                 www.nxp.com
+**     mail:                 support@nxp.com
+**
+**     Revisions:
+**     - rev. 1.0 (2021-11-16)
+**         Initial version.
+**
+** ###################################################################
+*/
+
+#ifndef _SYSTEM_MIMX9352_cm33_H_
+#define _SYSTEM_MIMX9352_cm33_H_ /**< Symbol preventing repeated inclusion */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "fsl_device_registers.h"
+
+#define DEFAULT_SYSTEM_CLOCK 200000000u
+
+/**
+ * @brief System clock frequency (core clock)
+ *
+ * The system clock frequency supplied to the SysTick timer and the processor
+ * core clock. This variable can be used by the user application to setup the
+ * SysTick timer or configure other parameters. It may also be used by debugger to
+ * query the frequency of the debug timer or configure the trace clock speed
+ * SystemCoreClock is initialized with a correct predefined value.
+ */
+extern uint32_t SystemCoreClock;
+
+/**
+ * @brief Setup the microcontroller system.
+ *
+ * Typically this function configures the oscillator (PLL) that is part of the
+ * microcontroller device. For systems with variable clock speed it also updates
+ * the variable SystemCoreClock. SystemInit is called from startup_device file.
+ */
+void SystemInit(void);
+
+/**
+ * @brief SystemInit function hook.
+ *
+ * This weak function allows to call specific initialization code during the
+ * SystemInit() execution.This can be used when an application specific code needs
+ * to be called as close to the reset entry as possible (for example the Multicore
+ * Manager MCMGR_EarlyInit() function call).
+ * NOTE: No global r/w variables can be used in this hook function because the
+ * initialization of these variables happens after this function.
+ */
+void SystemInitHook(void);
+
+/**
+ * @brief Updates the SystemCoreClock variable.
+ *
+ * It must be called whenever the core clock is changed during program
+ * execution. SystemCoreClockUpdate() evaluates the clock register settings and calculates
+ * the current core clock.
+ */
+void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYSTEM_MIMX9352_cm33_H_ */


### PR DESCRIPTION
This PR contains the hand-picked commits from https://github.com/zephyrproject-rtos/hal_nxp/pull/213 that should have also been merged into the mcux-sdk repo.