### PR TITLE
fsl_common: Add support for xt-clang compiler

### DIFF
--- a/drivers/common/driver_common.cmake
+++ b/drivers/common/driver_common.cmake
@@ -2,7 +2,7 @@
 include_guard(GLOBAL)
 message("driver_common component is included.")
 
-if((DEFINED CMAKE_C_COMPILER) AND (${CMAKE_C_COMPILER} MATCHES "xtensa"))
+if((DEFINED CMAKE_C_COMPILER) AND ((${CMAKE_C_COMPILER} MATCHES "xtensa") OR (${CMAKE_C_COMPILER} MATCHES "xt-clang")))
     set(MCUX_CPU_ARCH "DSP")
 endif()
 


### PR DESCRIPTION

**Prerequisites**

- [X] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [X] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

With newer toolchain versions (e.g RI-2023.11) Xtensa uses clang compiler.

Because the binary name for compiler is now xt-clang we fail to correctly identify MCUX_CPU_ARCH because we were looking for 'xtensa' string.

Fix this by also looking for 'xt-clang'.

**Type of change**
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: imx8mp
  - Toolchain: imx-audio-toolchain/Xtensa_Tool/install/tools/RI-2023.11-linux/XtensaTools/bin/xt-clang
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [X] Build Test
```
Go to SOF directory, setup Xtensa toolchain and run build script:

$ XTENSA_TOOLS_ROOT=~/work/repos/imx-audio-toolchain/Xtensa_Tool/ ./scripts/xtensa-build-zephyr.py imx8m
```
