### PR TITLE
Incorrect Fifo status on Message Lost

### DIFF
--- a/drivers/mcan/fsl_mcan.c
+++ b/drivers/mcan/fsl_mcan.c
@@ -1767,7 +1767,7 @@ void MCAN_TransferHandleIRQ(CAN_Type *base, mcan_handle_t *handle)
         else if (0U != (valueIR & (uint32_t)kMCAN_RxFifo1LostFlag))
         {
             result = (uint32_t)kMCAN_RxFifo1LostFlag;
-            status = kStatus_MCAN_RxFifo0Lost;
+            status = kStatus_MCAN_RxFifo1Lost;
         }
         else
         {


### PR DESCRIPTION
**Prerequisites**

- [Y] I have checked latest main branch and the issue still exists.
- [Y] I did not see it is stated as known-issue in release notes.
- [Y] No similar GitHub issue is related to this change.
- [Y] My code follows the commit guidelines of this project.
- [Y] I have performed a self-review of my own code.
- [Y] My changes generate no new warnings.
- [Y] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
Driver reports incorrect status when Message is lost in MCAN Fifo 1. Seems like it is a typo and the current change fixes the same.
-->

**Type of change**

- [Y] Bug fix (non-breaking change which fixes an issue)

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting:
  - Toolchain:
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [ ] Build Test
  - [ ] Run Test
