### PR TITLE
drivers: pit: fix compiler warning when clocks disabled

### DIFF
--- a/drivers/pit/fsl_pit.c
+++ b/drivers/pit/fsl_pit.c
@@ -23,15 +23,16 @@
  *
  * @return The PIT instance
  */
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 static uint32_t PIT_GetInstance(PIT_Type *base);
+#endif
 
 /*******************************************************************************
  * Variables
  ******************************************************************************/
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to PIT bases for each instance. */
 static PIT_Type *const s_pitBases[] = PIT_BASE_PTRS;
-
-#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to PIT clocks for each instance. */
 static const clock_ip_name_t s_pitClocks[] = PIT_CLOCKS;
 #endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
@@ -39,6 +40,7 @@ static const clock_ip_name_t s_pitClocks[] = PIT_CLOCKS;
 /*******************************************************************************
  * Code
  ******************************************************************************/
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 static uint32_t PIT_GetInstance(PIT_Type *base)
 {
     uint32_t instance;
@@ -56,6 +58,7 @@ static uint32_t PIT_GetInstance(PIT_Type *base)
 
     return instance;
 }
+#endif
 
 /*!
  * brief Ungates the PIT clock, enables the PIT module, and configures the peripheral for basic operations.


### PR DESCRIPTION
**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
Add missing guards to avoid compilation warnings when building PIT driver with clock control driver disabled.
Example of warning without this patch:
```
[136/182] Building C object modules/hal_nxp/hal_nxp/CM...__hal__nxp.dir/mcux/mcux-sdk/drivers/pit/fsl_pit.c.ob 
C:/Users/user/zephyr/modules/hal/nxp/mcux/mcux-sdk/drivers/pit/fsl_pit.c:42:17: warning: 'PIT_GetInstance' defined but not used [-Wunused-function]
   42 | static uint32_t PIT_GetInstance(PIT_Type *base)
      |
```

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: 
  - Toolchain: Zephyr SDK
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [x] Build Test
  - [x] Run Test
