### PR TITLE
devices: MIMX8ML8: Add support for new IRQSTEER driver

### DIFF
--- a/devices/MIMX8ML8/MIMX8ML8_dsp_features.h
+++ b/devices/MIMX8ML8/MIMX8ML8_dsp_features.h
@@ -469,5 +469,12 @@
 /* @brief Has no VSELECT bit in VEND_SPEC register */
 #define FSL_FEATURE_USDHC_HAS_NO_VOLTAGE_SELECT (1)
 
+/* IRQSTEER module features */
+
+/* @brief Number of IRQSTEER CHn_MASK registers */
+#define FSL_FEATURE_IRQSTEER_CHn_MASK_COUNT (5)
+/* @brief The start IRQ index of first IRQSTEER source IRQ */
+#define FSL_FEATURE_IRQSTEER_IRQ_START_INDEX (0)
+
 #endif /* _MIMX8ML8_dsp_FEATURES_H_ */
 

--- a/devices/MIMX8ML8/drivers/fsl_clock.h
+++ b/devices/MIMX8ML8/drivers/fsl_clock.h
@@ -44,6 +44,12 @@
  */
 #define CLKPAD_FREQ 0U
 
+/*! @brief Clock ip name array for IRQ_STEER. */
+#define IRQSTEER_CLOCKS					\
+    {							\
+        kCLOCK_AudioProcessorIrqsteer, kCLOCK_Hdmi,	\
+    }
+
 /*! @brief Clock ip name array for ECSPI. */
 #define ECSPI_CLOCKS                                                   \
     {                                                                  \
@@ -565,6 +571,8 @@ typedef enum _clock_ip_name
 
     kCLOCK_Sema42_1 = CCM_TUPLE(61U, 33U), /*!< RDC SEMA42 Clock Gate.*/
     kCLOCK_Sema42_2 = CCM_TUPLE(62U, 33U), /*!< RDC SEMA42 Clock Gate.*/
+
+    kCLOCK_AudioProcessorIrqsteer = CCM_TUPLE(63U, 33U), /*!< Audio Processor IRQ_STEER Clock Gate. */
 
     kCLOCK_Sim_enet   = CCM_TUPLE(64U, 17U), /*!< SIM_ENET Clock Gate.*/
     kCLOCK_Sim_m      = CCM_TUPLE(65U, 32U), /*!< SIM_M Clock Gate.*/


### PR DESCRIPTION
Since the Zephyr IRQSTEER driver doesn't use `IRQSTEER_Init()`/`IRQSTEER_Deinit()` I'm unable to test commit 2ce87ce