### PR TITLE
const-qualify buffer in UART_RTOS_Send

### DIFF
--- a/drivers/lpuart/fsl_lpuart_freertos.c
+++ b/drivers/lpuart/fsl_lpuart_freertos.c
@@ -350,7 +350,7 @@ int LPUART_RTOS_Receive(lpuart_rtos_handle_t *handle, uint8_t *buffer, uint32_t 
     }
 
     handle->rxTransfer.data     = buffer;
-    handle->rxTransfer.dataSize = (uint32_t)length;
+    handle->rxTransfer.dataSize = length;
 
     /* Non-blocking call */
     status = LPUART_TransferReceiveNonBlocking(handle->base, handle->t_state, &handle->rxTransfer, &n);

--- a/drivers/lpuart/fsl_lpuart_freertos.c
+++ b/drivers/lpuart/fsl_lpuart_freertos.c
@@ -229,7 +229,7 @@ int LPUART_RTOS_Deinit(lpuart_rtos_handle_t *handle)
  * param buffer The pointer to buffer to send.
  * param length The number of bytes to send.
  */
-int LPUART_RTOS_Send(lpuart_rtos_handle_t *handle, uint8_t *buffer, uint32_t length)
+int LPUART_RTOS_Send(lpuart_rtos_handle_t *handle, const uint8_t *buffer, uint32_t length)
 {
     EventBits_t ev;
     int retval = kStatus_Fail;
@@ -257,8 +257,8 @@ int LPUART_RTOS_Send(lpuart_rtos_handle_t *handle, uint8_t *buffer, uint32_t len
         return kStatus_Fail;
     }
 
-    handle->txTransfer.data     = (uint8_t *)buffer;
-    handle->txTransfer.dataSize = (uint32_t)length;
+    handle->txTransfer.txData   = buffer;
+    handle->txTransfer.dataSize = length;
 
     /* Non-blocking call */
     status = LPUART_TransferSendNonBlocking(handle->base, handle->t_state, &handle->txTransfer);

--- a/drivers/lpuart/fsl_lpuart_freertos.h
+++ b/drivers/lpuart/fsl_lpuart_freertos.h
@@ -140,7 +140,7 @@ int LPUART_RTOS_Deinit(lpuart_rtos_handle_t *handle);
  * @param buffer The pointer to buffer to send.
  * @param length The number of bytes to send.
  */
-int LPUART_RTOS_Send(lpuart_rtos_handle_t *handle, uint8_t *buffer, uint32_t length);
+int LPUART_RTOS_Send(lpuart_rtos_handle_t *handle, const uint8_t *buffer, uint32_t length);
 
 /*!
  * @brief Receives data.

--- a/drivers/uart/fsl_uart_freertos.c
+++ b/drivers/uart/fsl_uart_freertos.c
@@ -246,7 +246,7 @@ int UART_RTOS_Send(uart_rtos_handle_t *handle, const uint8_t *buffer, uint32_t l
     }
 
     handle->txTransfer.txData   = buffer;
-    handle->txTransfer.dataSize = (uint32_t)length;
+    handle->txTransfer.dataSize = length;
 
     /* Non-blocking call */
     status = UART_TransferSendNonBlocking(handle->base, handle->t_state, &handle->txTransfer);
@@ -322,7 +322,7 @@ int UART_RTOS_Receive(uart_rtos_handle_t *handle, uint8_t *buffer, uint32_t leng
     }
 
     handle->rxTransfer.data     = buffer;
-    handle->rxTransfer.dataSize = (uint32_t)length;
+    handle->rxTransfer.dataSize = length;
 
     /* Non-blocking call */
     status = UART_TransferReceiveNonBlocking(handle->base, handle->t_state, &handle->rxTransfer, &n);

--- a/drivers/uart/fsl_uart_freertos.c
+++ b/drivers/uart/fsl_uart_freertos.c
@@ -219,7 +219,7 @@ int UART_RTOS_Deinit(uart_rtos_handle_t *handle)
  * param buffer The pointer to the buffer to send.
  * param length The number of bytes to send.
  */
-int UART_RTOS_Send(uart_rtos_handle_t *handle, uint8_t *buffer, uint32_t length)
+int UART_RTOS_Send(uart_rtos_handle_t *handle, const uint8_t *buffer, uint32_t length)
 {
     EventBits_t ev;
     int retval = kStatus_Success;
@@ -245,7 +245,7 @@ int UART_RTOS_Send(uart_rtos_handle_t *handle, uint8_t *buffer, uint32_t length)
         return kStatus_Fail;
     }
 
-    handle->txTransfer.data     = (uint8_t *)buffer;
+    handle->txTransfer.txData   = buffer;
     handle->txTransfer.dataSize = (uint32_t)length;
 
     /* Non-blocking call */

--- a/drivers/uart/fsl_uart_freertos.h
+++ b/drivers/uart/fsl_uart_freertos.h
@@ -123,7 +123,7 @@ int UART_RTOS_Deinit(uart_rtos_handle_t *handle);
  * @param buffer The pointer to the buffer to send.
  * @param length The number of bytes to send.
  */
-int UART_RTOS_Send(uart_rtos_handle_t *handle, uint8_t *buffer, uint32_t length);
+int UART_RTOS_Send(uart_rtos_handle_t *handle, const uint8_t *buffer, uint32_t length);
 
 /*!
  * @brief Receives data.


### PR DESCRIPTION
This PR const-qualifies several variables in FSL API.
See issues #59 and #117 

- [x] Bug fix (non-breaking change which fixes an issue)
