### PR TITLE
drivers: ftm: fix compiler warning when clocks disabled

### DIFF
--- a/drivers/ftm/fsl_ftm.c
+++ b/drivers/ftm/fsl_ftm.c
@@ -17,15 +17,6 @@
  * Prototypes
  ******************************************************************************/
 /*!
- * @brief Gets the instance from the base address
- *
- * @param base FTM peripheral base address
- *
- * @return The FTM instance
- */
-static uint32_t FTM_GetInstance(FTM_Type *base);
-
-/*!
  * @brief Sets the FTM register PWM synchronization method
  *
  * This function will set the necessary bits for the PWM synchronization mode that
@@ -69,7 +60,7 @@ static const clock_ip_name_t s_ftmClocks[] = FTM_CLOCKS;
 /*******************************************************************************
  * Code
  ******************************************************************************/
-static uint32_t FTM_GetInstance(FTM_Type *base)
+uint32_t FTM_GetInstance(FTM_Type *base)
 {
     uint32_t instance;
     uint32_t ftmArrayCount = (sizeof(s_ftmBases) / sizeof(s_ftmBases[0]));

--- a/drivers/ftm/fsl_ftm.h
+++ b/drivers/ftm/fsl_ftm.h
@@ -635,6 +635,15 @@ void FTM_DisableInterrupts(FTM_Type *base, uint32_t mask);
  */
 uint32_t FTM_GetEnabledInterrupts(FTM_Type *base);
 
+/*!
+ * @brief Gets the instance from the base address
+ *
+ * @param base FTM peripheral base address
+ *
+ * @return The FTM instance
+ */
+uint32_t FTM_GetInstance(FTM_Type *base);
+
 /*! @}*/
 
 /*!


### PR DESCRIPTION
Add missing guards to avoid compilation warnings when building with clock control driver disabled.

**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
Add missing guards to avoid compilation warnings when building FTM driver with clock control driver disabled.
Example of warning without this patch:
```
Building C object modules/hal_nxp...dir/mcux/mcux-sdk/drivers/ftm/fsl_ftm.c.obj
/home/user/zephyrproject/modules/hal/nxp/mcux/mcux-sdk/drivers/ftm/fsl_ftm.c:72:17: warning: 'FTM_GetInstance' defined but not used [-Wunused-function]
   72 | static uint32_t FTM_GetInstance(FTM_Type *base)
      |
```

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting:
  - Toolchain: Zephyr SDK
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [x] Build Test
  - [x] Run Test
