### PR TITLE
drivers : caam : Move descriptors to noncacheable section

### DIFF
--- a/drivers/caam/fsl_caam.c
+++ b/drivers/caam/fsl_caam.c
@@ -213,6 +213,10 @@ static uint32_t s_jrIndex2              = 0;    /*!< Current index in the input 
 static caam_job_ring_interface_t *s_jr3 = NULL; /*!< Pointer to job ring interface 3. */
 static uint32_t s_jrIndex3              = 0;    /*!< Current index in the input job ring 3. */
 
+AT_NONCACHEABLE_SECTION(static caam_rng_config_t rngConfig);
+AT_NONCACHEABLE_SECTION(static caam_desc_rng_t rngGenSeckey);
+AT_NONCACHEABLE_SECTION(static caam_desc_rng_t rngInstantiate);
+AT_NONCACHEABLE_SECTION(static caam_desc_rng_t descBuf);
 /*******************************************************************************
  * Code
  ******************************************************************************/
@@ -1754,7 +1758,6 @@ status_t CAAM_Init(CAAM_Type *base, const caam_config_t *config)
      * for FIFO STORE command to be able to store Key register as Black key
      * for example during AES XCBC-MAC context switch (need to store derived key K1 to memory)
      */
-    caam_rng_config_t rngConfig;
     (void)CAAM_RNG_GetDefaultConfig(&rngConfig);
 
     /* reset RNG */
@@ -4089,7 +4092,6 @@ status_t CAAM_RNG_Init(CAAM_Type *base,
     status_t status;
 
     /* create job descriptor */
-    caam_desc_rng_t rngInstantiate = {0};
     rngInstantiate[0]              = 0xB0800006u;
     rngInstantiate[1]              = 0x12200020u; /* LOAD 32 bytes of  to Class 1 Context Register. Offset 0 bytes. */
     rngInstantiate[2]              = (uint32_t)ADD_OFFSET((uint32_t)config->personalString);
@@ -4185,7 +4187,6 @@ status_t CAAM_RNG_GenerateSecureKey(CAAM_Type *base, caam_handle_t *handle, caam
     status_t status;
 
     /* create job descriptor */
-    caam_desc_rng_t rngGenSeckey = {0};
     rngGenSeckey[0]              = 0xB0800004u; /* HEADER */
     rngGenSeckey[1]              = 0x12200020u; /* LOAD 32 bytes of  to Class 1 Context Register. Offset 0 bytes. */
     rngGenSeckey[2]              = ADD_OFFSET((uint32_t)additionalEntropy);
@@ -4292,7 +4293,6 @@ status_t CAAM_RNG_GetRandomData(CAAM_Type *base,
                                 caam_rng_generic256_t additionalEntropy)
 {
     status_t status;
-    caam_desc_rng_t descBuf;
 
     do
     {


### PR DESCRIPTION
Move used job descriptors in the CAAM driver from the stack to noncacheable section.

**Prerequisites**

- [] I have checked latest main branch and the issue still exists.

**Describe the pull request**
Fixes an issue the HAL_NXP patches with coherency of descriptors.
(https://github.com/zephyrproject-rtos/hal_nxp/pull/192)

**Type of change**
- [ ] Bug fix (non-breaking change which fixes an issue)

**Tests**

Part of the Zephyr enablement
