### PR TITLE
devices: MIMXRT685S fix I3C MDATACTRL UNLOCK def

### DIFF
--- a/devices/MIMXRT685S/MIMXRT685S_cm33.h
+++ b/devices/MIMXRT685S/MIMXRT685S_cm33.h
@@ -18964,8 +18964,8 @@ typedef struct {
  */
 #define I3C_MDATACTRL_FLUSHFB(x)                 (((uint32_t)(((uint32_t)(x)) << I3C_MDATACTRL_FLUSHFB_SHIFT)) & I3C_MDATACTRL_FLUSHFB_MASK)
 
-#define I3C_MDATACTRL_UNLOCK_MASK                (0x4U)
-#define I3C_MDATACTRL_UNLOCK_SHIFT               (2U)
+#define I3C_MDATACTRL_UNLOCK_MASK                (0x8U)
+#define I3C_MDATACTRL_UNLOCK_SHIFT               (3U)
 /*! UNLOCK - Unlock
  */
 #define I3C_MDATACTRL_UNLOCK(x)                  (((uint32_t)(((uint32_t)(x)) << I3C_MDATACTRL_UNLOCK_SHIFT)) & I3C_MDATACTRL_UNLOCK_MASK)


### PR DESCRIPTION
UNLOCK is actually bit 3, not bit 2

**Prerequisites**

- [X] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [X] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [ X] I have confirmed the fix using debugger

**Describe the pull request**
Fixes bit definition of I3C MDATACTRL UNLOCK

Fixes # (issue)
https://github.com/nxp-mcuxpresso/mcux-sdk/issues/164

**Type of change**
- [ X] Bug fix (non-breaking change which fixes an issue)

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: MIMXRT685S
- Test executed
  Observe MDATACTRL in debugger before/after I3C_SetWatermarks
