### PR TITLE
mcux: mcux-sdk: Fix labels in inline assembly

### DIFF
--- a/components/css_pkc/src/comps/mcuxCsslMemory/inc/impl/mcuxCsslMemory_Compare_asm.h
+++ b/components/css_pkc/src/comps/mcuxCsslMemory/inc/impl/mcuxCsslMemory_Compare_asm.h
@@ -29,7 +29,7 @@ do{  \
     uint8_t dat_lhs, dat_rhs;  \
     __asm volatile (  \
         "EOR    %[_retval], %[_result], %[_notValid]\n" /* retval should now be 0xFFFFFFFF */\
-        "loop:\n" /* Comparison; in case of equality retval should remain 0xFFFFFFFF throughout the loop. */\
+        "loop%=:\n" /* Comparison; in case of equality retval should remain 0xFFFFFFFF throughout the loop. */\
         "LDRB   %[_dat_lhs], [%[_cur_lhs]], #+1\n"        \
         "LDRB   %[_dat_rhs], [%[_cur_rhs]], #+1\n"        \
         "EORS   %[_dat_lhs], %[_dat_lhs], %[_dat_rhs]\n"  \
@@ -37,7 +37,7 @@ do{  \
         "SUBS   %[_cnt], %[_cnt], #+1\n"                  \
         "MVN    %[_dat_rhs], %[_dat_lhs]\n"               \
         "AND    %[_retval], %[_retval], %[_dat_rhs]\n"    \
-        "BNE    loop\n"  \
+        "BNE    loop%=\n"  \
         : [_retval] "=r" (retval_),    \
           [_cur_lhs] "+r" (cur_lhs_),  \
           [_cur_rhs] "+r" (cur_rhs_),  \

--- a/drivers/common/fsl_common_arm.c
+++ b/drivers/common/fsl_common_arm.c
@@ -159,11 +159,11 @@ static void DelayLoop(uint32_t count)
 {
     __ASM volatile("    MOV    X0, %0" : : "r"(count));
     __ASM volatile(
-        "loop:                          \n"
+        "loop%=:                        \n"
         "    SUB    X0, X0, #1          \n"
         "    CMP    X0, #0              \n"
 
-        "    BNE    loop                \n"
+        "    BNE    loop%=              \n"
         :
         :
         : "r0");
@@ -176,7 +176,7 @@ static void DelayLoop(uint32_t count)
 {
     __ASM volatile("    MOV    R0, %0" : : "r"(count));
     __ASM volatile(
-        "loop:                          \n"
+        "loop%=:                        \n"
 #if defined(__GNUC__) && !defined(__ARMCC_VERSION)
         "    SUB    R0, R0, #1          \n"
 #else
@@ -184,7 +184,7 @@ static void DelayLoop(uint32_t count)
 #endif
         "    CMP    R0, #0              \n"
 
-        "    BNE    loop                \n"
+        "    BNE    loop%=              \n"
         :
         :
         : "r0");


### PR DESCRIPTION
This commit fixes labels in inline assembly to use unique identifiers for internal labels.
This fix is required to be able to use LTO.

**Prerequisites**

- [ ] I have checked latest main branch and the issue still exists.
- [ ] I did not see it is stated as known-issue in release notes.
- [ ] No similar GitHub issue is related to this change.
- [ ] My code follows the commit guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

Detected and fixed here: https://github.com/zephyrproject-rtos/zephyr/pull/66392