### PR TITLE
drivers: fsl_dma: Fix incorrect access of common registers

### DIFF
--- a/drivers/lpc_dma/fsl_dma.c
+++ b/drivers/lpc_dma/fsl_dma.c
@@ -481,7 +481,7 @@ void DMA_AbortTransfer(dma_handle_t *handle)
             (1UL << DMA_CHANNEL_INDEX(handle->base, handle->channel))) != 0UL)
     {
     }
-    DMA_COMMON_REG_GET(handle->base, handle->channel, ABORT) |= 1UL << DMA_CHANNEL_INDEX(handle->base, handle->channel);
+    DMA_COMMON_REG_SET(handle->base, handle->channel, ABORT, 1UL << DMA_CHANNEL_INDEX(handle->base, handle->channel));
     DMA_EnableChannel(handle->base, handle->channel);
 }
 

--- a/drivers/lpc_dma/fsl_dma.h
+++ b/drivers/lpc_dma/fsl_dma.h
@@ -380,7 +380,7 @@ static inline void DMA_EnableChannelInterrupts(DMA_Type *base, uint32_t channel)
 {
     assert((FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(base) != -1) &&
            (channel < (uint32_t)FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(base)));
-    DMA_COMMON_REG_GET(base, channel, INTENSET) |= 1UL << DMA_CHANNEL_INDEX(base, channel);
+    DMA_COMMON_REG_SET(base, channel, INTENSET, 1UL << DMA_CHANNEL_INDEX(base, channel));
 }
 
 /*!
@@ -393,7 +393,7 @@ static inline void DMA_DisableChannelInterrupts(DMA_Type *base, uint32_t channel
 {
     assert((FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(base) != -1) &&
            (channel < (uint32_t)FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(base)));
-    DMA_COMMON_REG_GET(base, channel, INTENCLR) |= 1UL << DMA_CHANNEL_INDEX(base, channel);
+    DMA_COMMON_REG_SET(base, channel, INTENCLR, 1UL << DMA_CHANNEL_INDEX(base, channel));
 }
 
 /*!
@@ -406,7 +406,7 @@ static inline void DMA_EnableChannel(DMA_Type *base, uint32_t channel)
 {
     assert((FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(base) != -1) &&
            (channel < (uint32_t)FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(base)));
-    DMA_COMMON_REG_GET(base, channel, ENABLESET) |= 1UL << DMA_CHANNEL_INDEX(base, channel);
+    DMA_COMMON_REG_SET(base, channel, ENABLESET, 1UL << DMA_CHANNEL_INDEX(base, channel));
 }
 
 /*!
@@ -419,7 +419,7 @@ static inline void DMA_DisableChannel(DMA_Type *base, uint32_t channel)
 {
     assert((FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(base) != -1) &&
            (channel < (uint32_t)FSL_FEATURE_DMA_NUMBER_OF_CHANNELSn(base)));
-    DMA_COMMON_REG_GET(base, channel, ENABLECLR) |= 1UL << DMA_CHANNEL_INDEX(base, channel);
+    DMA_COMMON_REG_SET(base, channel, ENABLECLR, 1UL << DMA_CHANNEL_INDEX(base, channel));
 }
 
 /*!


### PR DESCRIPTION
**Prerequisites**
- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
The `SET` and `CLR` peripheral registers will set and clear bits in the underlying register without requiring a racy read-modify-write sequence. ABORT is write-only and has essentially the same semantics.

The current code using |= defeats this safety and in a multithreaded environment, this could inadvetently set bits which were recently cleared by another thread.

Replace the use of `DMA_COMMON_REG_GET(...) |= 1 << x` with `DMA_COMMON_REG_SET(..., | 1 << x)` to only write a 1 to the desired bit, leaving all others alone.

Fixes: #173

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**Tests**
TBD

- Test configuration (please complete the following information):
  - Hardware setting: MIMXRT595 in custom application
  - Toolchain: ARM GCC
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [] Build Test
  - [ ] Run Test
