### PR TITLE
west: Add submanifests

### DIFF
--- a/submanifests/README.txt
+++ b/submanifests/README.txt
@@ -1,0 +1,10 @@
+This directory can contain additional west manifest files. Any files
+in this directory will be included in the main west.yml file sorted by
+filename.
+
+See example.yaml.sample for an example.
+
+For more details about how this works, see this part of the west
+documentation:
+
+https://docs.zephyrproject.org/latest/guides/west/manifest.html#example-2-2-downstream-with-directory-of-manifest-files

--- a/submanifests/example.yaml.sample
+++ b/submanifests/example.yaml.sample
@@ -1,0 +1,18 @@
+# Example manifest file you can include into the main west.yml file.
+#
+# To make this work, copy this file's contents to a new file,
+# 'example.yaml', in the same directory.
+#
+# Then change the 'name' and 'url' below and run 'west update'.
+#
+# Your module will be added to the local workspace and kept in sync
+# every time you run 'west update'.
+#
+# If you want to fetch a particular commit rather than the main
+# branch, change the 'revision' line accordingly.
+
+manifest:
+  projects:
+    - name: my-module
+      url: https://github.com/my-username/my-module
+      revision: main

--- a/west.yml
+++ b/west.yml
@@ -128,3 +128,4 @@ manifest:
     remote: nxp
   self:
     path: core
+    import: submanifests


### PR DESCRIPTION
Allow to import additional repositories with submanifests which won't generate merge conflicts in the west.yaml file.

The README.txt and example.yaml.sample were copied from the Zephyr Project.