### PR TITLE
fix the dma request source error of LPSPI3;

### DIFF
--- a/devices/MIMXRT1042/MIMXRT1042.h
+++ b/devices/MIMXRT1042/MIMXRT1042.h
@@ -1118,8 +1118,6 @@ typedef enum _dma_request_source
     kDmaRequestMuxCAN3              = 11|0x100U,   /**< CAN3 */
     kDmaRequestMuxLPSPI1Rx          = 13|0x100U,   /**< LPSPI1 Receive */
     kDmaRequestMuxLPSPI1Tx          = 14|0x100U,   /**< LPSPI1 Transmit */
-    kDmaRequestMuxLPSPI3Rx          = 15|0x100U,   /**< LPSPI3 Receive */
-    kDmaRequestMuxLPSPI3Tx          = 16|0x100U,   /**< LPSPI3 Transmit */
     kDmaRequestMuxLPI2C1            = 17|0x100U,   /**< LPI2C1 */
     kDmaRequestMuxLPI2C3            = 18|0x100U,   /**< LPI2C3 */
     kDmaRequestMuxSai1Rx            = 19|0x100U,   /**< SAI1 Receive */
@@ -1178,6 +1176,8 @@ typedef enum _dma_request_source
     kDmaRequestMuxLCDIF             = 76|0x100U,   /**< LCDIF */
     kDmaRequestMuxLPSPI2Rx          = 77|0x100U,   /**< LPSPI2 Receive */
     kDmaRequestMuxLPSPI2Tx          = 78|0x100U,   /**< LPSPI2 Transmit */
+    kDmaRequestMuxLPSPI3Rx          = 79|0x100U,   /**< LPSPI3 Receive */
+    kDmaRequestMuxLPSPI3Tx          = 80|0x100U,   /**< LPSPI3 Transmit */
     kDmaRequestMuxLPI2C2            = 81|0x100U,   /**< LPI2C2 */
     kDmaRequestMuxLPI2C4            = 82|0x100U,   /**< LPI2C4 */
     kDmaRequestMuxSai3Rx            = 83|0x100U,   /**< SAI3 Receive */


### PR DESCRIPTION
**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->

fix the dma request source error of LPSPI3 accoording to `IMXRT1040RM Rev. 1, 09/2022`.
![Snipaste_2024-07-23_09-55-05](https://github.com/user-attachments/assets/41c10fcb-d583-49da-86b7-a72568f6c8d7)

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [x] Bug fix (non-breaking change which fixes an issue)

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: board -> evkmimxrt1040, io -> GPIO_B0_03_LPSPI3_SCK, IOMUXC_GPIO_B0_02_LPSPI3_SDO, IOMUXC_GPIO_B0_00_LPSPI3_PCS0, IOMUXC_GPIO_B0_01_LPSPI3_SDI
  - Toolchain: MDK
  - Test Tool preparation: a Logic analyzer.
  - Any other dependencies: No
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
In `\evkmimxrt1040\driver_examples\lpspi\edma_b2b_transfer`, change the LPSPI from `LPSPI1` to `LPSPI3`. 
If no dma request source change is made, the program is stuck, unable to trigger dma interrupt, `LPSPI_MasterUserCallback()` cannot be executed, and data cannot be sent; on the contrary, the program proceeds smoothly, the data was sent successfully.

  - [x] Build Test
  - [x] Run Test
