### PR TITLE
DSPI: Improve support for dummy data larger than 8 bits

### DIFF
--- a/drivers/dspi/fsl_dspi.c
+++ b/drivers/dspi/fsl_dspi.c
@@ -115,7 +115,7 @@ static dspi_master_isr_t s_dspiMasterIsr;
 static dspi_slave_isr_t s_dspiSlaveIsr;
 
 /* @brief Dummy data for each instance. This data is used when user's tx buffer is NULL*/
-volatile uint8_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
+volatile uint16_t g_dspiDummyData[ARRAY_SIZE(s_dspiBases)] = {0};
 /**********************************************************************************************************************
  * Code
  *********************************************************************************************************************/
@@ -150,20 +150,20 @@ uint32_t DSPI_GetInstance(SPI_Type *base)
  *
  * param base DSPI peripheral base address.
  */
-uint8_t DSPI_GetDummyDataInstance(SPI_Type *base)
+uint16_t DSPI_GetDummyDataInstance(SPI_Type *base)
 {
-    uint8_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
+    uint16_t instance = g_dspiDummyData[DSPI_GetInstance(base)];
 
     return instance;
 }
 
-/*!
- * brief Set up the dummy data.
- *
- * param base DSPI peripheral address.
- * param dummyData Data to be transferred when tx buffer is NULL.
- */
 void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData)
+{
+    uint32_t instance         = DSPI_GetInstance(base);
+    g_dspiDummyData[instance] = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
+}
+
+void DSPI_SetDummyData16Bit(SPI_Type *base, uint16_t dummyData)
 {
     uint32_t instance         = DSPI_GetInstance(base);
     g_dspiDummyData[instance] = dummyData;
@@ -888,7 +888,7 @@ status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 
     uint16_t wordToSend   = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData     = DSPI_GetDummyDataInstance(base);
+    uint16_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t bitsPerFrame;
 
     uint32_t command;
@@ -1849,7 +1849,7 @@ static void DSPI_SlaveTransferFillUpTxFifo(SPI_Type *base, dspi_slave_handle_t *
     assert(NULL != handle);
 
     uint16_t transmitData = 0;
-    uint8_t dummyPattern  = DSPI_GetDummyDataInstance(base);
+    uint16_t dummyPattern  = DSPI_GetDummyDataInstance(base);
 
     /* Service the transmitter, if transmit buffer provided, transmit the data,
      * else transmit dummy pattern
@@ -2001,7 +2001,7 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle)
 {
     assert(NULL != handle);
 
-    uint8_t dummyPattern = DSPI_GetDummyDataInstance(base);
+    uint16_t dummyPattern = DSPI_GetDummyDataInstance(base);
     uint32_t dataReceived;
     uint32_t dataSend                     = 0;
     uint32_t tmpRemainingReceiveByteCount = 0;

--- a/drivers/dspi/fsl_dspi.h
+++ b/drivers/dspi/fsl_dspi.h
@@ -21,7 +21,7 @@
 
 /*! @name Driver version */
 /*! @{ */
-/*! @brief DSPI driver version 2.2.5. */
+/*! @brief DSPI driver version 2.2.6. */
 #define FSL_DSPI_DRIVER_VERSION (MAKE_VERSION(2, 2, 6))
 /*! @} */
 
@@ -31,7 +31,7 @@
 #endif
 
 /*! @brief Global variable for dummy data value setting. */
-extern volatile uint8_t g_dspiDummyData[];
+extern volatile uint16_t g_dspiDummyData[];
 
 /*! @brief Status for the DSPI driver.*/
 enum
@@ -1038,8 +1038,19 @@ static inline uint32_t DSPI_ReadData(SPI_Type *base)
  *
  * @param base DSPI peripheral address.
  * @param dummyData Data to be transferred when tx buffer is NULL.
+ *
+ * @note This version of the dummy data setter will construct the upper 8 bits of the dummy data
+ *    to be the same as the lower 8 bits.
  */
 void DSPI_SetDummyData(SPI_Type *base, uint8_t dummyData);
+
+/*!
+ * @brief Set up the dummy data as a 16-bit value.
+ *
+ * @param base DSPI peripheral address.
+ * @param dummyData Data to be transferred when tx buffer is NULL.
+ */
+void DSPI_SetDummyData16Bit(SPI_Type *base, uint16_t dummyData);
 
 /*!
  *@}
@@ -1221,7 +1232,7 @@ void DSPI_SlaveTransferHandleIRQ(SPI_Type *base, dspi_slave_handle_t *handle);
  *
  * param base DSPI peripheral base address.
  */
-uint8_t DSPI_GetDummyDataInstance(SPI_Type *base);
+uint16_t DSPI_GetDummyDataInstance(SPI_Type *base);
 
 /*!
  *@}

--- a/drivers/dspi/fsl_dspi_edma.c
+++ b/drivers/dspi/fsl_dspi_edma.c
@@ -161,7 +161,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
 
     uint32_t instance                = DSPI_GetInstance(base);
     uint16_t wordToSend              = 0;
-    uint8_t dummyData                = DSPI_GetDummyDataInstance(base);
+    uint16_t dummyData               = DSPI_GetDummyDataInstance(base);
     uint8_t dataAlreadyFed           = 0;
     uint8_t dataFedMax               = 2;
     uint32_t tmpMCR                  = 0;
@@ -279,7 +279,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 }
                 else
                 {
-                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
+                    wordToSend = dummyData;
                 }
                 handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
                 handle->command     = handle->lastCommand;
@@ -295,7 +295,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                 }
                 else
                 {
-                    wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
+                    wordToSend = dummyData;
                 }
                 handle->command = (handle->command & 0xffff0000U) | wordToSend;
             }
@@ -346,7 +346,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                     }
                     else
                     {
-                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
+                        wordToSend = dummyData;
                     }
                     handle->remainingSendByteCount = 0;
                     base->PUSHR                    = (handle->lastCommand & 0xffff0000U) | wordToSend;
@@ -363,7 +363,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
                     }
                     else
                     {
-                        wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
+                        wordToSend = dummyData;
                     }
                     handle->remainingSendByteCount -= 2U;
                     base->PUSHR = (handle->command & 0xffff0000U) | wordToSend;
@@ -513,14 +513,7 @@ status_t DSPI_MasterTransferEDMA(SPI_Type *base, dspi_master_edma_handle_t *hand
         }
         else
         {
-            if (handle->bitsPerFrame <= 8U)
-            {
-                wordToSend = dummyData;
-            }
-            else
-            {
-                wordToSend = (((uint16_t)dummyData << 8U) | (uint16_t)dummyData);
-            }
+            wordToSend = dummyData;
             handle->lastCommand = (handle->lastCommand & 0xffff0000U) | wordToSend;
         }
     }
@@ -1219,7 +1212,7 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
     handle->totalByteCount            = transfer->dataSize;
 
     uint32_t wordToSend    = 0;
-    uint8_t dummyData      = DSPI_GetDummyDataInstance(base);
+    uint16_t dummyData     = DSPI_GetDummyDataInstance(base);
     uint8_t dataAlreadyFed = 0;
     uint8_t dataFedMax     = 2;
 
@@ -1262,7 +1255,7 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
                 }
                 else
                 {
-                    wordToSend = ((uint32_t)dummyData << 8U) | dummyData;
+                    wordToSend = dummyData;
                 }
                 handle->remainingSendByteCount -= 2U; /* decrement remainingSendByteCount by 2 */
                 base->PUSHR_SLAVE = wordToSend;
@@ -1373,14 +1366,7 @@ status_t DSPI_SlaveTransferEDMA(SPI_Type *base, dspi_slave_edma_handle_t *handle
         {
             transferConfigC.srcAddr   = (uint32_t)(&handle->txBuffIfNull);
             transferConfigC.srcOffset = 0;
-            if (handle->bitsPerFrame <= 8U)
-            {
-                handle->txBuffIfNull = dummyData;
-            }
-            else
-            {
-                handle->txBuffIfNull = ((uint32_t)dummyData << 8U) | dummyData;
-            }
+            handle->txBuffIfNull = dummyData;
         }
 
         transferConfigC.srcTransferSize = kEDMA_TransferSize1Bytes;


### PR DESCRIPTION
**Prerequisites**

- [X] I have checked latest main branch and the issue still exists.
- [X] I did not see it is stated as known-issue in release notes.
- [X] No similar GitHub issue is related to this change.
- [] My code follows the commit guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->
I am working on MK64F support in Mbed Community Edition, and noticed some issues related to the dummy data support in the DSPI peripheral driver.  Specifically:
- For transfers done using the `fsl_dspi` driver, if the SPI frame size is >8, the upper 8 bits are always sent as 0s, regardless of dummy data setting.
- For transfers done using the `fsl_dspi_edma` driver, the upper 8 bits always match the bottom 8 bits.  This is most of the time what you want, but why not let the user change it?

This PR fixes this by widening the dummy data variable to 16 bits.  If the old-style `DSPI_SetDummyData` version is used, the upper 8 bits are set to match the lower 8 bits.  If the new `DSPI_SetDummyData16Bit` function is called, the entire 16-bit word can be set at once.

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting:
  - Toolchain:
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [ ] Build Test
  - [ ] Run Test

Currently I have tested this in-tree with Mbed CE.  I verified with a logic analyzer that, for `fsl_dspi` transfers, 16-bit dummy data is sent.  I still need to test this with the DMA version of the code.  If this testing is not sufficient, please advise on what other manual tests I should do / test programs I should add!