### PR TITLE
Add function to get MU RX status flags

### DIFF
--- a/drivers/mu/fsl_mu.h
+++ b/drivers/mu/fsl_mu.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015, Freescale Semiconductor, Inc.
- * Copyright 2016-2023 NXP
+ * Copyright 2016-2024 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -371,6 +371,33 @@ static inline uint32_t MU_GetStatusFlags(MU_Type *base)
                         | MU_SR_HRIP_MASK
 #endif
                         ));
+}
+
+/*!
+ * @brief Return the RX status flags.
+ *
+ * This function return the RX status flags.
+ * Note: RFn bits of SR[27-24](mu status register) are
+ * mapped in reverse numerical order:
+ *      RF0 -> SR[27]
+ *      RF1 -> SR[26]
+ *      RF2 -> SR[25]
+ *      RF3 -> SR[24]
+ *
+ * @code
+ * status_reg = MU_GetRxStatusFlags(base);
+ * @endcode
+ *
+ * @param base MU peripheral base address.
+ * @return MU RX status
+ */
+
+static inline uint32_t MU_GetRxStatusFlags(MU_Type *base)
+{
+    uint32_t flags = 0;
+    flags = ((MU_GetStatusFlags(base) >> (MU_SR_RFn_SHIFT + 0U)) & 0x0000000FU);
+
+    return flags;
 }
 
 /*!

--- a/drivers/mu1/fsl_mu.h
+++ b/drivers/mu1/fsl_mu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 NXP
+ * Copyright 2021-2024 NXP
  * All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -891,6 +891,41 @@ static inline uint32_t MU_GetGeneralPurposeStatusFlags(MU_Type *base)
 static inline void MU_ClearGeneralPurposeStatusFlags(MU_Type *base, uint32_t flags)
 {
     base->GSR = flags;
+}
+
+/*!
+ * @brief Return the RX status flags in reverse numerical order.
+ *
+ * This function return the RX status flags in reverse order.
+ * Note: RFn bits of SR[3-0](mu status register) are
+ * mapped in ascending numerical order:
+ *      RF0 -> SR[0]
+ *      RF1 -> SR[1]
+ *      RF2 -> SR[2]
+ *      RF3 -> SR[3]
+ * This function will return these bits in reverse numerical
+ * order(RF3->RF1) to comply with MU_GetRxStatusFlags() of
+ * mu driver. See MU_GetRxStatusFlags() from drivers/mu/fsl_mu.h
+ *
+ * @code
+ * status_reg = MU_GetRxStatusFlags(base);
+ * @endcode
+ *
+ * @param base MU peripheral base address.
+ * @return MU RX status flags in reverse order
+ */
+
+static inline uint32_t MU_GetRxStatusFlags(MU_Type *base)
+{
+    uint32_t flags = 0;
+    flags = ((base->RSR >> MU_RSR_RF0_SHIFT) & 0x0000000FU);
+    flags = (((flags >> MU_RSR_RF3_SHIFT) << MU_RSR_RF0_SHIFT) |
+             ((flags >> MU_RSR_RF2_SHIFT) << MU_RSR_RF1_SHIFT) |
+             ((flags >> MU_RSR_RF1_SHIFT) << MU_RSR_RF2_SHIFT) |
+             ((flags >> MU_RSR_RF0_SHIFT) << MU_RSR_RF3_SHIFT))
+             & 0x0000000FU;
+
+    return flags;
 }
 
 /*!


### PR DESCRIPTION
The fsl_mu.h driver need a function
(static inline uint32_t MU_GetRxStatusFlags(MU_Type *base)) that get the MU RX status flags, because ipm_imx.c driver from zephyr/drivers/ipm get the RX status flags directly from MU register instead of using a function. As ipm_imx.c driver is used by multiple imx platforms that have different MU regiter map layout, each platform need to implement a
'static inline uint32_t MU_GetRxStatusFlags(MU_Type *base)' function that will be used by the ipm_imx.c in imx_mu_isr(). As imx_mu_isr() parse the RX status flags in reverse numerical order, the function need to return the RX status flags the same way.

**Prerequisites**

- [ ] I have checked latest main branch and the issue still exists.
- [ ] I did not see it is stated as known-issue in release notes.
- [ ] No similar GitHub issue is related to this change.
- [ ] My code follows the commit guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting:
  - Toolchain:
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [ ] Build Test
  - [ ] Run Test
