### PR TITLE
components: log: fix typo

### DIFF
--- a/components/log/fsl_component_log.c
+++ b/components/log/fsl_component_log.c
@@ -524,7 +524,7 @@ void LOG_Printf(log_module_t const *module, log_level_t level, unsigned int time
 {
     va_list ap;
     log_print_buffer_t buffer;
-    uint8_t printBuf[LOG_MAX_MEESSAGE_LENGTH];
+    uint8_t printBuf[LOG_MAX_MESSAGE_LENGTH];
 
     (void)module;
 
@@ -549,7 +549,7 @@ void LOG_Printf(log_module_t const *module, log_level_t level, unsigned int time
 #endif
     {
         buffer.buffer = printBuf;
-        buffer.length = LOG_MAX_MEESSAGE_LENGTH;
+        buffer.length = LOG_MAX_MESSAGE_LENGTH;
         buffer.sofar  = 0;
     }
 

--- a/components/log/fsl_component_log.h
+++ b/components/log/fsl_component_log.h
@@ -490,7 +490,7 @@ void LOG_AsyncPrintf(log_module_t const *module,
  *
  * @details This function dumps one log bufferred in log component.
  * Only the buffer and length are valid, the outLength will be filled with valid value.
- * The message will be discarded when the message is more than LOG_MAX_MEESSAGE_LENGTH or buffer length
+ * The message will be discarded when the message is more than LOG_MAX_MESSAGE_LENGTH or buffer length
  * passed by the function.
  *
  * @param buffer The buffer to dump the message.

--- a/components/log/fsl_component_log_config.h
+++ b/components/log/fsl_component_log_config.h
@@ -112,13 +112,13 @@
  * want to enable the feature.@n For IAR, right click project and select "Options", define it in "C/C++
  * Compiler->Preprocessor->Defined symbols".@n For KEIL, click "Options for Target...", define it in
  * "C/C++->Preprocessor Symbols->Define".@n For ARMGCC, open CmakeLists.txt and add the following lines,@n
- * "SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DLOG_MAX_MEESSAGE_LENGTH=128")" for debug target.@n
- * "SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -DLOG_MAX_MEESSAGE_LENGTH=128")" for release target.@n
+ * "SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DLOG_MAX_MESSAGE_LENGTH=128")" for debug target.@n
+ * "SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -DLOG_MAX_MESSAGE_LENGTH=128")" for release target.@n
  * For MCUxpresso, right click project and select "Properties", define it in "C/C++ Build->Settings->MCU C
  * Complier->Preprocessor".@n
  */
-#ifndef LOG_MAX_MEESSAGE_LENGTH
-#define LOG_MAX_MEESSAGE_LENGTH 128
+#ifndef LOG_MAX_MESSAGE_LENGTH
+#define LOG_MAX_MESSAGE_LENGTH 128
 #endif
 
 /*! @brief Whether enable asynchronous log mode feature, 1 - enable, 0 - disable.


### PR DESCRIPTION
Fix LOG_MAX_MESSAGE_LENGTH typo in log component.

Signed-off-by: Javier Santos <jasr93@outlook.es>

**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**

Fix LOG_MAX_MESSAGE_LENGTH typo in log component.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting:
  - Toolchain:
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [x] Build Test
  - [ ] Run Test
