### PR TITLE
CAAM: Add MD5, SHA512/224 and SHA512/256

### DIFF
--- a/drivers/caam/fsl_caam.h
+++ b/drivers/caam/fsl_caam.h
@@ -257,11 +257,14 @@ typedef enum _caam_hash_algo_t
 {
     kCAAM_XcbcMac = 0, /*!< XCBC-MAC (AES engine) */
     kCAAM_Cmac,        /*!< CMAC (AES engine) */
+    kCAAM_Md5,         /*!< MD5     (MDHA engine)  */
     kCAAM_Sha1,        /*!< SHA_1   (MDHA engine)  */
     kCAAM_Sha224,      /*!< SHA_224 (MDHA engine)  */
     kCAAM_Sha256,      /*!< SHA_256 (MDHA engine)  */
     kCAAM_Sha384,      /*!< SHA_384 (MDHA engine)  */
     kCAAM_Sha512,      /*!< SHA_512 (MDHA engine)  */
+    kCAAM_Sha512_224,  /*!< SHA_512_224 (MDHA engine)  */
+    kCAAM_Sha512_256,  /*!< SHA_512_256 (MDHA engine)  */
     kCAAM_HmacSha1,    /*!< HMAC_SHA_1   (MDHA engine)  */
     kCAAM_HmacSha224,  /*!< HMAC_SHA_224 (MDHA engine)  */
     kCAAM_HmacSha256,  /*!< HMAC_SHA_256 (MDHA engine)  */


### PR DESCRIPTION
**Prerequisites**

- [ ] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
This change adds support for MD5, SHA-512/224, and SHA-512/256 algorithms to the NXP CAAM driver.

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting: i.MX RT117x
  - Toolchain: any
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [x] Build Test
  - [x] Run Test
