### PR TITLE
Correct FLEXSPI_TransferNonBlocking doxygen reference

### DIFF
--- a/drivers/flexspi/fsl_flexspi.h
+++ b/drivers/flexspi/fsl_flexspi.h
@@ -850,7 +850,7 @@ void FLEXSPI_TransferCreateHandle(FLEXSPI_Type *base,
  * @brief Performs a interrupt non-blocking transfer on the FLEXSPI bus.
  *
  * @note Calling the API returns immediately after transfer initiates. The user needs
- * to call FLEXSPI_GetTransferCount to poll the transfer status to check whether
+ * to call FLEXSPI_TransferGetCount to poll the transfer status to check whether
  * the transfer is finished. If the return status is not kStatus_FLEXSPI_Busy, the transfer
  * is finished. For FLEXSPI_Read, the dataSize should be multiple of rx watermark level, or
  * FLEXSPI could not read data properly.


### PR DESCRIPTION
**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->

This PR aims to correct the doxygen reference of FLEXSPI_TransferGetCount in FLEXSPI_TransferNonBlocking and is a non-functional change.

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [x] This change requires a documentation update

**Tests**

No tests were executed as it's a doxygen reference update.
