### PR TITLE
fix compiler warning when built with zephyr

### DIFF
--- a/drivers/hashcrypt/fsl_hashcrypt.c
+++ b/drivers/hashcrypt/fsl_hashcrypt.c
@@ -75,7 +75,7 @@ static hashcrypt_hash_ctx_t *s_ctx;
 
 /*!< macro for checking build time condition. It is used to assure the hashcrypt_sha_ctx_internal_t can fit into
  * hashcrypt_hash_ctx_t */
-#define BUILD_ASSERT(condition, msg) extern int msg[1 - 2 * (!(condition))] __attribute__((unused))
+#define _FSL_HASHCRYPT_BUILD_ASSERT(condition, msg) extern int msg[1 - 2 * (!(condition))] __attribute__((unused))
 
 /*******************************************************************************
  * Code
@@ -948,7 +948,7 @@ status_t HASHCRYPT_SHA_Init(HASHCRYPT_Type *base, hashcrypt_hash_ctx_t *ctx, has
 
     hashcrypt_sha_ctx_internal_t *ctxInternal;
     /* compile time check for the correct structure size */
-    BUILD_ASSERT(sizeof(hashcrypt_hash_ctx_t) >= sizeof(hashcrypt_sha_ctx_internal_t), hashcrypt_hash_ctx_t_size);
+    _FSL_HASHCRYPT_BUILD_ASSERT(sizeof(hashcrypt_hash_ctx_t) >= sizeof(hashcrypt_sha_ctx_internal_t), hashcrypt_hash_ctx_t_size);
 
     status = hashcrypt_sha_check_input_args(base, ctx, algo);
     if (status != kStatus_Success)

--- a/drivers/sha/fsl_sha.c
+++ b/drivers/sha/fsl_sha.c
@@ -65,7 +65,7 @@ enum _sha_digest_len
 static sha_ctx_t *s_shaCtx = NULL;
 
 /*!< macro for checking build time condition. It is used to assure the sha_ctx_internal_t can fit into sha_ctx_t */
-#define BUILD_ASSERT(condition, msg) extern int msg[1 - 2 * (!(condition))] __attribute__((unused))
+#define _FSL_SHA_BUILD_ASSERT(condition, msg) extern int msg[1 - 2 * (!(condition))] __attribute__((unused))
 
 /*******************************************************************************
  * Code
@@ -502,7 +502,7 @@ status_t SHA_Init(SHA_Type *base, sha_ctx_t *ctx, sha_algo_t algo)
 
     sha_ctx_internal_t *ctxInternal;
     /* compile time check for the correct structure size */
-    BUILD_ASSERT(sizeof(sha_ctx_t) >= sizeof(sha_ctx_internal_t), sha_ctx_t_size);
+    _FSL_SHA_BUILD_ASSERT(sizeof(sha_ctx_t) >= sizeof(sha_ctx_internal_t), sha_ctx_t_size);
     uint32_t i;
 
     status = sha_check_input_args(base, ctx, algo);


### PR DESCRIPTION
when building with zephyr, fsl_hashcrypt.c and fsl_sha.c triggers compiler warnings due to the macro BUILD_ASSERT being already defined.

rename the macros to have unique names to avoid this.

**Prerequisites**

- [x] I have checked latest main branch and the issue still exists.
- [x] I did not see it is stated as known-issue in release notes.
- [x] No similar GitHub issue is related to this change.
- [x] My code follows the commit guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [-] I have added tests that prove my fix is effective or that my feature works.

**Describe the pull request**
<!--
A clear and concise description for the change in this Pull Request and which issue is fixed.

Fixes # (issue)
-->

fixes a compilation warning.

**Type of change**
<!--
(please delete options that are not relevant)
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Tests**

- Test configuration (please complete the following information):
  - Hardware setting:
  - Toolchain:
  - Test Tool preparation:
  - Any other dependencies:
- Test executed
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  - [x] Build Test
  - [ ] Run Test

note: is this the correct repo for this? i have found https://github.com/nxp-mcuxpresso/mcuxsdk-core but it's unclear which branch to merge to in that repository.